### PR TITLE
Clean up warnings in gleam_core::build

### DIFF
--- a/compiler-core/src/build.rs
+++ b/compiler-core/src/build.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2021 The Gleam contributors
 
-#![allow(warnings)]
-
 mod elixir_libraries;
 mod module_loader;
 mod native_file_copier;
@@ -20,19 +18,16 @@ pub use self::project_compiler::{Built, Options, ProjectCompiler};
 pub use self::telemetry::{NullTelemetry, Telemetry};
 
 use crate::ast::{
-    self, CallArg, CustomType, DefinitionLocation, TypeAst, TypedArg, TypedClauseGuard,
-    TypedConstant, TypedCustomType, TypedDefinitions, TypedExpr, TypedFunction, TypedImport,
-    TypedModuleConstant, TypedPattern, TypedRecordConstructor, TypedStatement, TypedTypeAlias,
+    self, CustomType, DefinitionLocation, TypeAst, TypedArg, TypedClauseGuard, TypedConstant,
+    TypedCustomType, TypedDefinitions, TypedExpr, TypedFunction, TypedImport, TypedModuleConstant,
+    TypedPattern, TypedRecordConstructor, TypedStatement, TypedTypeAlias,
 };
 use crate::reference;
 use crate::type_::error::Named;
 use crate::type_::{Type, TypedCallArg};
 use crate::{
-    ast::{Definition, SrcSpan, TypedModule},
-    config::{self, PackageConfig},
-    erlang,
-    error::{Error, FileIoAction, FileKind},
-    io::OutputFile,
+    ast::{SrcSpan, TypedModule},
+    config::PackageConfig,
     parse::extra::{Comment, ModuleExtra},
     type_,
 };
@@ -41,12 +36,11 @@ use clap::ValueEnum;
 use ecow::EcoString;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
-use std::fmt::{Debug, Display};
+use std::fmt::Debug;
 use std::sync::Arc;
 use std::time::SystemTime;
-use std::{collections::HashMap, ffi::OsString, fs::DirEntry, iter::Peekable, process};
-use strum::{Display, EnumIter, EnumString, EnumVariantNames, VariantNames};
-use vec1::Vec1;
+use std::{collections::HashMap, iter::Peekable};
+use strum::{Display, EnumIter, EnumString, VariantNames};
 
 #[derive(
     Debug,
@@ -54,7 +48,7 @@ use vec1::Vec1;
     Deserialize,
     ValueEnum,
     EnumString,
-    EnumVariantNames,
+    VariantNames,
     EnumIter,
     Clone,
     Copy,
@@ -136,11 +130,12 @@ impl Codegen {
 }
 
 #[derive(
+    Default,
     Debug,
     Serialize,
     Deserialize,
     EnumString,
-    EnumVariantNames,
+    VariantNames,
     ValueEnum,
     Clone,
     Copy,
@@ -154,6 +149,7 @@ pub enum Runtime {
     #[strum(serialize = "node")]
     #[serde(alias = "node")]
     #[clap(alias = "node")]
+    #[default]
     NodeJs,
     Deno,
     Bun,
@@ -166,12 +162,6 @@ impl Runtime {
             Runtime::Deno => "Deno",
             Runtime::Bun => "Bun",
         }
-    }
-}
-
-impl Default for Runtime {
-    fn default() -> Self {
-        Self::NodeJs
     }
 }
 
@@ -211,7 +201,7 @@ pub struct ErlangAppCodegenConfiguration {
     Deserialize,
     Display,
     EnumString,
-    EnumVariantNames,
+    VariantNames,
     EnumIter,
     Clone,
     Copy,
@@ -258,7 +248,7 @@ pub struct Package {
 
 impl Package {
     pub fn attach_doc_and_module_comments(&mut self) {
-        for mut module in &mut self.modules {
+        for module in &mut self.modules {
             module.attach_doc_and_module_comments();
         }
     }
@@ -526,7 +516,7 @@ pub enum Located<'a> {
     Arg(&'a TypedArg),
     Annotation {
         ast: &'a TypeAst,
-        type_: std::sync::Arc<Type>,
+        type_: Arc<Type>,
     },
     TypeVariable {
         name: EcoString,
@@ -537,13 +527,13 @@ pub enum Located<'a> {
     Label {
         location: SrcSpan,
         /// The type of the labelled argument's value (used for hover).
-        field_type: std::sync::Arc<Type>,
+        field_type: Arc<Type>,
     },
     /// A record field label at its definition in a custom type variant.
     RecordLabelDefinition {
         location: SrcSpan,
         /// The type of the field (used for hover).
-        field_type: std::sync::Arc<Type>,
+        field_type: Arc<Type>,
         label: EcoString,
         /// The name of the custom type this field belongs to. The type is
         /// being defined in the module being analysed, so only its name is
@@ -555,10 +545,10 @@ pub enum Located<'a> {
     RecordLabelUsage {
         location: SrcSpan,
         /// The type of the field's value (used for hover).
-        field_type: std::sync::Arc<Type>,
+        field_type: Arc<Type>,
         label: EcoString,
         /// The record type the field belongs to.
-        record_type: std::sync::Arc<Type>,
+        record_type: Arc<Type>,
         /// The name of the variant the field was used with.
         variant: EcoString,
     },
@@ -566,10 +556,10 @@ pub enum Located<'a> {
     RecordAccessLabel {
         location: SrcSpan,
         /// The type of the field (used for hover).
-        field_type: std::sync::Arc<Type>,
+        field_type: Arc<Type>,
         label: EcoString,
         /// The record type the field belongs to.
-        record_type: std::sync::Arc<Type>,
+        record_type: Arc<Type>,
         /// The documentation of the field (used for hover).
         documentation: Option<EcoString>,
     },
@@ -595,7 +585,7 @@ impl<'a> Located<'a> {
     fn type_location(
         &self,
         importable_modules: &'a im::HashMap<EcoString, type_::ModuleInterface>,
-        type_: std::sync::Arc<Type>,
+        type_: Arc<Type>,
     ) -> Option<DefinitionLocation> {
         type_constructor_from_modules(importable_modules, type_).map(|t| DefinitionLocation {
             module: Some(t.module.clone()),
@@ -649,7 +639,7 @@ impl<'a> Located<'a> {
                 span: *location,
             }),
             Self::Statement(statement) => statement.definition_location(),
-            Self::FunctionBody(statement) => None,
+            Self::FunctionBody(_statement) => None,
             Self::Expression { expression, .. } => expression.definition_location(),
 
             Self::ModuleImport(import) => Some(DefinitionLocation {
@@ -772,9 +762,9 @@ impl<'a> Located<'a> {
 /// This is what powers the "go to type definition" capability of the language
 /// server.
 ///
-fn type_to_definition_locations<'a>(
+fn type_to_definition_locations(
     type_: Arc<Type>,
-    importable_modules: &'a im::HashMap<EcoString, type_::ModuleInterface>,
+    importable_modules: &im::HashMap<EcoString, type_::ModuleInterface>,
 ) -> Vec<DefinitionLocation> {
     match type_.as_ref() {
         // For named types we start with the location of the named type itself
@@ -794,7 +784,7 @@ fn type_to_definition_locations<'a>(
                 return vec![];
             };
 
-            let Some(type_) = module.get_importable_type(&name) else {
+            let Some(type_) = module.get_importable_type(name) else {
                 return vec![];
             };
 
@@ -845,14 +835,14 @@ fn type_to_definition_locations<'a>(
 // Looks up the type constructor for the given type
 pub fn type_constructor_from_modules(
     importable_modules: &im::HashMap<EcoString, type_::ModuleInterface>,
-    type_: std::sync::Arc<Type>,
+    type_: Arc<Type>,
 ) -> Option<&type_::TypeConstructor> {
     let type_ = type_::collapse_links(type_);
     match type_.as_ref() {
         Type::Named { name, module, .. } => importable_modules
             .get(module)
             .and_then(|i| i.types.get(name)),
-        _ => None,
+        Type::Fn { .. } | Type::Var { .. } | Type::Tuple { .. } => None,
     }
 }
 
@@ -929,7 +919,7 @@ fn doc_comments_before<'a>(
     (comment_start, comments)
 }
 
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize)]
 pub struct SourceFingerprint(u64);
 
 impl SourceFingerprint {

--- a/compiler-core/src/build/elixir_libraries.rs
+++ b/compiler-core/src/build/elixir_libraries.rs
@@ -109,10 +109,10 @@ where
         let read_pathfinder = self.io.read(&cache)?;
         for lib_path in read_pathfinder.split('\n') {
             let source = Utf8PathBuf::from(lib_path);
-            let name = source.as_path().file_name().expect(&format!(
-                "Unexpanded path in {}",
-                self.paths_cache_filename()
-            ));
+            let name = source
+                .as_path()
+                .file_name()
+                .unwrap_or_else(|| panic!("Unexpanded path in {}", self.paths_cache_filename()));
             let dest = self.build_dir.join(name);
             let ebin = dest.join("ebin");
             if !update_links || self.io.is_directory(&ebin) {

--- a/compiler-core/src/build/module_loader.rs
+++ b/compiler-core/src/build/module_loader.rs
@@ -9,7 +9,6 @@ use std::{collections::HashSet, time::SystemTime};
 use camino::{Utf8Path, Utf8PathBuf};
 
 use ecow::EcoString;
-use serde::{Deserialize, Serialize};
 
 use super::{
     Mode, Origin, SourceFingerprint, Target,
@@ -20,7 +19,7 @@ use crate::{
     Error, Result,
     error::{FileIoAction, FileKind},
     io::{CommandExecutor, FileSystemReader, FileSystemWriter},
-    warning::{TypeWarningEmitter, WarningEmitter},
+    warning::WarningEmitter,
 };
 
 #[derive(Debug)]
@@ -58,7 +57,7 @@ where
 
         let meta = match self.read_cache_metadata(&file)? {
             Some(meta) => meta,
-            None => return read_source(name).map(Input::New),
+            None => return read_source(name).map(|module| Input::New(Box::new(module))),
         };
 
         // The cache currently does not contain enough data to perform codegen,
@@ -66,7 +65,7 @@ where
         // that codegen has already been performed before using a cache.
         if self.codegen.is_required() && !meta.codegen_performed {
             tracing::debug!(?name, "codegen_required_cache_insufficient");
-            return read_source(name).map(Input::New);
+            return read_source(name).map(|module| Input::New(Box::new(module)));
         }
 
         // If the timestamp of the source is newer than the cache entry and
@@ -76,12 +75,12 @@ where
             let source_module = read_source(name.clone())?;
             if meta.fingerprint != SourceFingerprint::new(&source_module.code) {
                 tracing::debug!(?name, "cache_stale");
-                return Ok(Input::New(source_module));
+                return Ok(Input::New(Box::new(source_module)));
             } else if self.mode == Mode::Lsp && self.incomplete_modules.contains(&name) {
                 // Since the lsp can have valid but incorrect intermediate code states between
                 // successful compilations, we need to invalidate the cache even if the fingerprint matches
                 tracing::debug!(?name, "cache_stale for lsp");
-                return Ok(Input::New(source_module));
+                return Ok(Input::New(Box::new(source_module)));
             }
         }
 
@@ -91,7 +90,7 @@ where
     /// Read the cache metadata file from the artefact directory for the given
     /// source file. If the file does not exist, return `None`.
     fn read_cache_metadata(&self, source_file: &GleamFile) -> Result<Option<CacheMetadata>> {
-        let meta_path = source_file.cache_files(&self.artefact_directory).meta_path;
+        let meta_path = source_file.cache_files(self.artefact_directory).meta_path;
 
         if !self.io.is_file(&meta_path) {
             return Ok(None);
@@ -133,11 +132,11 @@ where
             source_path: file.path,
             origin: self.origin,
             name: file.module_name,
-            line_numbers: meta.line_numbers,
         }
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn read_source<IO>(
     io: IO,
     target: Target,

--- a/compiler-core/src/build/native_file_copier.rs
+++ b/compiler-core/src/build/native_file_copier.rs
@@ -63,7 +63,7 @@ where
     /// Returns a list of files that need to be compiled (Elixir and Erlang).
     ///
     pub fn run(mut self) -> Result<CopiedNativeFiles> {
-        self.io.mkdir(&self.destination_dir)?;
+        self.io.mkdir(self.destination_dir)?;
 
         let src = self.paths.src_directory();
         self.copy_files(&src)?;
@@ -90,7 +90,7 @@ where
     fn copy_files(&mut self, src_root: &Utf8Path) -> Result<()> {
         let mut dir_walker = DirWalker::new(src_root.to_path_buf());
         while let Some(path) = dir_walker.next_file(&self.io)? {
-            self.copy(path, &src_root)?;
+            self.copy(path, src_root)?;
         }
         Ok(())
     }
@@ -187,9 +187,7 @@ where
         // Insert the full relative `.mjs` path in `seen_modules` as there is
         // no conflict if two `.mjs` files have the same name but are in
         // different subpaths, unlike Erlang files.
-        let existing = self
-            .seen_modules
-            .insert(mjs_path.clone(), relative_path.clone());
+        let existing = self.seen_modules.insert(mjs_path, relative_path.clone());
 
         // If there was no already existing one then there's no problem.
         let Some(existing) = existing else {
@@ -213,9 +211,9 @@ where
         // The only way for two `.mjs` files to clash is by having
         // the exact same path.
         assert_eq!(&existing, relative_path);
-        return Err(Error::DuplicateSourceFile {
+        Err(Error::DuplicateSourceFile {
             file: existing.to_string(),
-        });
+        })
     }
 
     /// Erlang module files cannot have the same name regardless of their

--- a/compiler-core/src/build/native_file_copier/tests.rs
+++ b/compiler-core/src/build/native_file_copier/tests.rs
@@ -3,13 +3,13 @@
 
 use super::NativeFileCopier;
 use crate::{
-    build::{native_file_copier::CopiedNativeFiles, package_compiler::CheckModuleConflicts},
+    build::package_compiler::CheckModuleConflicts,
     io::{FileSystemWriter, memory::InMemoryFileSystem},
 };
 use std::{
     collections::HashMap,
     sync::OnceLock,
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::{Duration, UNIX_EPOCH},
 };
 
 use camino::{Utf8Path, Utf8PathBuf};

--- a/compiler-core/src/build/package_compiler.rs
+++ b/compiler-core/src/build/package_compiler.rs
@@ -4,39 +4,37 @@
 #[cfg(test)]
 mod tests;
 
-use crate::analyse::{ModuleAnalyzerConstructor, TargetSupport};
+use crate::analyse::TargetSupport;
 use crate::build::package_loader::CacheFiles;
 
 use crate::error::{DefinedModuleOrigin, FailedModule, SkipReason, SkippedModule};
-use crate::io::files_with_extension;
-use crate::line_numbers::{self, LineNumbers};
+use crate::line_numbers::LineNumbers;
+use crate::metadata;
 use crate::type_::PRELUDE_MODULE_NAME;
 use crate::type_::printer::Names;
 use crate::{
     Error, Result, Warning,
-    ast::{SrcSpan, TypedModule, UntypedModule},
+    ast::{SrcSpan, UntypedModule},
     build::{
-        Mode, Module, Origin, Outcome, Package, SourceFingerprint, Target,
+        Mode, Module, Origin, Outcome, SourceFingerprint, Target,
         elixir_libraries::ElixirLibraries,
         native_file_copier::NativeFileCopier,
         package_loader::{CodegenRequired, PackageLoader, StaleTracker},
     },
     codegen::{Erlang, ErlangApp, JavaScript, TypeScriptDeclarations},
     config::PackageConfig,
-    dep_tree, error,
     io::{BeamCompilerIO, CommandExecutor, FileSystemReader, FileSystemWriter, Stdio},
     parse::extra::ModuleExtra,
     paths, type_,
     uid::UniqueIdGenerator,
     warning::{TypeWarningEmitter, WarningEmitter},
 };
-use crate::{inline, metadata};
 use askama::Template;
 use ecow::EcoString;
-use itertools::Itertools;
-use std::collections::HashSet;
-use std::{collections::HashMap, fmt::write, time::SystemTime};
-use vec1::Vec1;
+use std::{
+    collections::{HashMap, HashSet},
+    time::SystemTime,
+};
 
 use camino::{Utf8Path, Utf8PathBuf};
 
@@ -82,6 +80,7 @@ impl<'a, IO> PackageCompiler<'a, IO>
 where
     IO: FileSystemReader + FileSystemWriter + CommandExecutor + BeamCompilerIO + Clone,
 {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         config: &'a PackageConfig,
         mode: Mode,
@@ -197,7 +196,7 @@ where
         // Type check the modules that are new or have changed
         tracing::info!(count=%loaded.to_compile.len(), "analysing_modules");
         let outcome = analyse(
-            &self.config,
+            self.config,
             self.target.target(),
             self.mode,
             &self.ids,
@@ -266,7 +265,7 @@ where
 
         self.io
             .compile_beam(self.out, self.lib, modules, self.subprocess_stdio)
-            .map(|modules| modules.iter().map(|str| EcoString::from(str)).collect())
+            .map(|modules| modules.iter().map(EcoString::from).collect())
     }
 
     fn copy_project_native_files(
@@ -286,13 +285,13 @@ where
 
         let copier = NativeFileCopier::new(
             self.io.clone(),
-            self.root.clone(),
+            self.root,
             destination_dir,
             self.check_module_conflicts,
         );
         let copied = copier.run()?;
 
-        to_compile_modules.extend(copied.to_compile.into_iter());
+        to_compile_modules.extend(copied.to_compile);
 
         // If there are any Elixir files then we need to locate Elixir
         // installed on this system for use in compilation.
@@ -421,7 +420,7 @@ where
         if let Some(config) = app_file_config {
             ErlangApp::new(&self.out.join("ebin"), config).render(
                 io,
-                &self.config,
+                self.config,
                 modules,
                 cached_module_names,
                 native_modules,
@@ -444,16 +443,16 @@ where
             TypeScriptDeclarations::None
         };
         JavaScript::new(
-            &self.out,
+            self.out,
             typescript,
             sourcemaps,
             prelude_location,
-            &self.root,
+            self.root,
         )
         .render(&self.io, modules, self.stdlib_package())?;
 
         if self.copy_native_files {
-            self.copy_project_native_files(&self.out, &mut written)?;
+            self.copy_project_native_files(self.out, &mut written)?;
         } else {
             tracing::debug!("skipping_native_file_copying");
         }
@@ -483,7 +482,7 @@ where
         // If the file does not exist then linking is needed. It could already
         // exist due to having been linked by a previous compilation run.
         if !file_at_destination {
-            return self.io.hardlink(&source, &destination);
+            return self.io.hardlink(source, &destination);
         }
 
         // If file is already there then there is nothing to do.
@@ -491,12 +490,12 @@ where
         // If there is already a file there but it is not a link that means
         // it is a link to the source file for a previous module that had
         // the same name.
-        if self.io.is_same_file(&source, &destination)? {
+        if self.io.is_same_file(source, &destination)? {
             return Ok(());
         }
 
         self.io.delete_file(&destination)?;
-        self.io.hardlink(&source, &destination)
+        self.io.hardlink(source, &destination)
     }
 
     fn render_erlang_entrypoint_module(
@@ -558,12 +557,13 @@ pub enum StdlibPackage {
     Missing,
 }
 
+#[allow(clippy::too_many_arguments)]
 fn analyse(
     package_config: &PackageConfig,
     target: Target,
     mode: Mode,
     ids: &UniqueIdGenerator,
-    mut parsed_modules: Vec<UncompiledModule>,
+    parsed_modules: Vec<UncompiledModule>,
     module_types: &mut im::HashMap<EcoString, type_::ModuleInterface>,
     warnings: &WarningEmitter,
     target_support: TargetSupport,
@@ -590,9 +590,9 @@ fn analyse(
         path,
         mtime,
         origin,
-        package,
         dependencies,
         extra,
+        ..
     } in parsed_modules
     {
         tracing::debug!(module = ?name, "Type checking");
@@ -601,7 +601,7 @@ fn analyse(
         // If we weren't able to compile one of the modules it depends on, then
         // we have to skip this one to avoid reporting false errors.
         let skipped_dependency = dependencies.iter().find_map(|(dependency, location)| {
-            if let Some(failed_module) = failed_modules.get(dependency) {
+            if let Some(_failed_module) = failed_modules.get(dependency) {
                 // This module imports a module with an error.
                 let reason = SkipReason::DependencyHasError {
                     name: dependency.clone(),
@@ -680,7 +680,7 @@ fn analyse(
                     .map(|interface| interface.values.is_empty() && interface.types.is_empty())
                     .unwrap_or(false)
                 {
-                    warnings.emit(crate::warning::Warning::EmptyModule {
+                    warnings.emit(Warning::EmptyModule {
                         path: module.input_path.clone(),
                         name: module.name.clone(),
                     });
@@ -715,7 +715,7 @@ fn analyse(
                     module.name.clone(),
                     FailedModule {
                         names: Box::new(names),
-                        path: path,
+                        path,
                         src: code,
                         errors,
                     },
@@ -760,7 +760,7 @@ fn analyse(
 
 #[derive(Debug)]
 pub(crate) enum Input {
-    New(UncompiledModule),
+    New(Box<UncompiledModule>),
     Cached(CachedModule),
 }
 
@@ -789,6 +789,7 @@ impl Input {
     /// Returns `true` if the input is [`New`].
     ///
     /// [`New`]: Input::New
+    #[cfg(test)]
     #[must_use]
     pub(crate) fn is_new(&self) -> bool {
         matches!(self, Self::New(..))
@@ -797,6 +798,7 @@ impl Input {
     /// Returns `true` if the input is [`Cached`].
     ///
     /// [`Cached`]: Input::Cached
+    #[cfg(test)]
     #[must_use]
     pub(crate) fn is_cached(&self) -> bool {
         matches!(self, Self::Cached(..))
@@ -809,7 +811,6 @@ pub(crate) struct CachedModule {
     pub origin: Origin,
     pub dependencies: Vec<(EcoString, SrcSpan)>,
     pub source_path: Utf8PathBuf,
-    pub line_numbers: LineNumbers,
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]

--- a/compiler-core/src/build/package_compiler/tests.rs
+++ b/compiler-core/src/build/package_compiler/tests.rs
@@ -9,8 +9,8 @@ use ecow::EcoString;
 use crate::{
     Error,
     build::{
-        self, NullTelemetry, Outcome, PackageCompiler, StaleTracker, Target,
-        TargetCodegenConfiguration, Telemetry, package_compiler::Compiled,
+        self, NullTelemetry, Outcome, PackageCompiler, StaleTracker, TargetCodegenConfiguration,
+        package_compiler::Compiled,
     },
     config::PackageConfig,
     error::DefinedModuleOrigin,
@@ -24,7 +24,7 @@ fn compile_modules(
     module: &str,
     existing_modules: Vec<(&str, &str)>,
 ) -> Outcome<Compiled, Error> {
-    let mut fs = InMemoryFileSystem::new();
+    let fs = InMemoryFileSystem::new();
     fs.write(
         Utf8Path::new(&format!("/src/{module}.gleam")),
         "pub fn main() -> Nil { Nil }",

--- a/compiler-core/src/build/package_loader.rs
+++ b/compiler-core/src/build/package_loader.rs
@@ -7,7 +7,6 @@ mod tests;
 use std::{
     collections::{HashMap, HashSet},
     sync::OnceLock,
-    time::{Duration, SystemTime},
 };
 
 use camino::{Utf8Path, Utf8PathBuf};
@@ -22,11 +21,10 @@ use vec1::Vec1;
 use crate::{
     Error, Result,
     ast::SrcSpan,
-    build::{Module, Origin, module_loader::ModuleLoader},
-    config::PackageConfig,
+    build::{Origin, module_loader::ModuleLoader},
     dep_tree,
     error::{DefinedModuleOrigin, FileIoAction, FileKind, ImportCycleLocationDetails},
-    io::{self, CommandExecutor, FileSystemReader, FileSystemWriter, files_with_extension},
+    io::{CommandExecutor, FileSystemReader, FileSystemWriter, files_with_extension},
     metadata,
     paths::ProjectPaths,
     type_,
@@ -37,9 +35,7 @@ use crate::{
 use super::{
     Mode, Target,
     module_loader::read_source,
-    package_compiler::{
-        CacheMetadata, CachedModule, CachedWarnings, Input, Loaded, UncompiledModule,
-    },
+    package_compiler::{CachedModule, CachedWarnings, Input, Loaded, UncompiledModule},
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -79,6 +75,7 @@ impl<'a, IO> PackageLoader<'a, IO>
 where
     IO: FileSystemWriter + FileSystemReader + CommandExecutor + Clone,
 {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         io: IO,
         ids: UniqueIdGenerator,
@@ -120,10 +117,10 @@ where
         // Check for any removed modules, by looking at cache files that don't exist in inputs.
         // Delete the cache files for removed modules and mark them as stale
         // to trigger refreshing dependent modules.
-        for module in CacheFiles::modules_with_meta_files(&self.io, &self.artefact_directory) {
-            if (!inputs.contains_key(&module)) {
+        for module in CacheFiles::modules_with_meta_files(&self.io, self.artefact_directory) {
+            if !inputs.contains_key(&module) {
                 tracing::debug!(%module, "module_removed");
-                CacheFiles::new(&self.artefact_directory, &module).delete(&self.io)?;
+                CacheFiles::new(self.artefact_directory, &module).delete(&self.io)?;
                 self.stale_modules.add(module);
             }
         }
@@ -160,7 +157,7 @@ where
                 Input::New(module) => {
                     tracing::debug!(module = %module.name, "new_module_to_be_compiled");
                     self.stale_modules.add(module.name.clone());
-                    loaded.to_compile.push(module);
+                    loaded.to_compile.push(*module);
                 }
 
                 // A cached module with dependencies that are stale must be
@@ -187,7 +184,7 @@ where
     }
 
     fn load_cached_module(&self, info: CachedModule) -> Result<type_::ModuleInterface, Error> {
-        let cache_files = CacheFiles::new(&self.artefact_directory, &info.name);
+        let cache_files = CacheFiles::new(self.artefact_directory, &info.name);
         let bytes = self.io.read_bytes(&cache_files.cache_path)?;
         let mut module = match metadata::decode(bytes.as_slice(), self.ids.clone()) {
             Ok(module) => module,
@@ -279,7 +276,7 @@ where
         // "code". Emit an error so this never happens.
         if self.target.is_erlang() {
             for (_, input) in inputs.collection.values() {
-                ensure_gleam_module_does_not_overwrite_standard_erlang_module(&input)?;
+                ensure_gleam_module_does_not_overwrite_standard_erlang_module(input)?;
             }
         }
 
@@ -294,7 +291,7 @@ where
         // next time the dependencies might no longer be stale, but we still need to be able to tell
         // that this module needs to be recompiled until it successfully compiles at least once.
         // This can happen if the stale dependency includes breaking changes.
-        CacheFiles::new(&self.artefact_directory, &cached.name).delete(&self.io)?;
+        CacheFiles::new(self.artefact_directory, &cached.name).delete(&self.io)?;
 
         read_source(
             self.io.clone(),
@@ -1705,7 +1702,7 @@ impl<'a> Inputs<'a> {
             .insert(name.clone(), origin.clone())
         {
             return Err(Error::DuplicateModule {
-                module: name.clone(),
+                module: name,
                 first,
                 second: origin,
             });
@@ -1737,7 +1734,7 @@ static IS_GLEAM_PATH_PATTERN: OnceLock<Regex> = OnceLock::new();
 impl GleamFile {
     pub fn new(dir: &Utf8Path, path: Utf8PathBuf) -> Self {
         Self {
-            module_name: Self::module_name(&path, &dir),
+            module_name: Self::module_name(&path, dir),
             path,
         }
     }
@@ -1753,7 +1750,7 @@ impl GleamFile {
     ) -> impl Iterator<Item = Result<Self, crate::Warning>> + 'b {
         tracing::trace!("gleam_source_files {:?}", dir);
         files_with_extension(io, dir, "gleam").map(move |path| {
-            if (Self::is_gleam_path(&path, &dir)) {
+            if Self::is_gleam_path(&path, dir) {
                 Ok(Self::new(dir, path))
             } else {
                 Err(crate::Warning::InvalidSource { path })
@@ -1825,7 +1822,7 @@ impl CacheFiles {
         }
     }
 
-    pub fn delete(&self, io: &dyn io::FileSystemWriter) -> Result<()> {
+    pub fn delete(&self, io: &dyn FileSystemWriter) -> Result<()> {
         io.delete_file(&self.cache_path)?;
         io.delete_file(&self.meta_path)
     }
@@ -1838,7 +1835,7 @@ impl CacheFiles {
         dir: &'a Utf8Path,
     ) -> impl Iterator<Item = EcoString> + 'a {
         tracing::trace!("CacheFiles::modules_with_meta_files {:?}", dir);
-        files_with_extension(io, dir, "cache_meta").map(move |path| Self::module_name(&dir, &path))
+        files_with_extension(io, dir, "cache_meta").map(move |path| Self::module_name(dir, &path))
     }
 
     fn module_name(dir: &Utf8Path, path: &Utf8Path) -> EcoString {

--- a/compiler-core/src/build/package_loader/tests.rs
+++ b/compiler-core/src/build/package_loader/tests.rs
@@ -1,21 +1,20 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023 The Gleam contributors
 
-use ecow::{EcoString, eco_format};
+use ecow::EcoString;
 use hexpm::version::Version;
 
 use super::*;
 use crate::{
     Warning,
     build::SourceFingerprint,
+    build::package_compiler::CacheMetadata,
     io::{FileSystemWriter, memory::InMemoryFileSystem},
     line_numbers,
-    parse::extra::ModuleExtra,
     type_::References,
-    warning::NullWarningEmitterIO,
 };
 
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 #[derive(Debug)]
 struct LoaderTestOutput {
@@ -54,7 +53,7 @@ fn write_cache(
     let path = Utf8Path::new("/artefact").join(format!("{artefact_name}.cache_meta"));
     fs.write_bytes(&path, &cache_metadata.to_binary()).unwrap();
 
-    let cache = crate::type_::ModuleInterface {
+    let cache = type_::ModuleInterface {
         name: name.into(),
         origin: Origin::Src,
         package: "my_package".into(),

--- a/compiler-core/src/build/project_compiler.rs
+++ b/compiler-core/src/build/project_compiler.rs
@@ -2,40 +2,30 @@
 // SPDX-FileCopyrightText: 2020 The Gleam contributors
 
 use crate::{
-    Error, Result, Warning,
+    Error, Result,
     analyse::TargetSupport,
     build::{
-        Mode, Module, Origin, Package, Target,
-        package_compiler::{self, PackageCompiler},
-        package_loader::StaleTracker,
-        project_compiler,
-        telemetry::Telemetry,
+        Mode, Module, Package, Target, package_compiler::PackageCompiler,
+        package_loader::StaleTracker, telemetry::Telemetry,
     },
-    codegen::{self, ErlangApp},
     config::PackageConfig,
     dep_tree,
     error::{DefinedModuleOrigin, FileIoAction, FileKind, ShellCommandFailureReason},
     io::{BeamCompilerIO, Command, CommandExecutor, FileSystemReader, FileSystemWriter, Stdio},
     manifest::{ManifestPackage, ManifestPackageSource},
-    metadata,
     paths::{self, ProjectPaths},
     type_::{self, ModuleFunction},
     uid::UniqueIdGenerator,
     version::COMPILER_VERSION,
-    warning::{self, WarningEmitter, WarningEmitterIO},
+    warning::{WarningEmitter, WarningEmitterIO},
 };
 use ecow::EcoString;
 use hexpm::version::Version;
 use itertools::Itertools;
-use pubgrub::Range;
 use std::{
     cmp,
     collections::{HashMap, HashSet},
-    fmt::Write,
-    io::BufReader,
     rc::Rc,
-    sync::Arc,
-    time::Instant,
 };
 
 use super::{
@@ -58,7 +48,7 @@ const ELIXIR_EXECUTABLE: &str = "elixir";
 #[cfg(target_os = "windows")]
 const ELIXIR_EXECUTABLE: &str = "elixir.bat";
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct Options {
     pub mode: Mode,
     pub target: Option<Target>,
@@ -73,7 +63,6 @@ pub struct Options {
 pub struct Built {
     pub root_package: Package,
     pub module_interfaces: im::HashMap<EcoString, type_::ModuleInterface>,
-    compiled_dependency_modules: Vec<Module>,
 }
 
 impl Built {
@@ -96,7 +85,7 @@ impl Built {
             .values()
             .map(|interface| &interface.minimum_required_version)
             .reduce(|one_version, other_version| cmp::max(one_version, other_version))
-            .map(|minimum_required_version| minimum_required_version.clone())
+            .cloned()
             .unwrap_or(Version::new(0, 1, 0))
     }
 }
@@ -177,9 +166,9 @@ where
 
         self.stale_modules.empty();
 
-        /// We also clear the defined modules, otherwise the language server
-        /// would start throwing errors for modules defined twice when compiling
-        /// a second time!
+        // We also clear the defined modules, otherwise the language server
+        // would start throwing errors for modules defined twice when compiling
+        // a second time!
         self.defined_modules.clear();
     }
 
@@ -216,7 +205,7 @@ where
         self.write_prelude()?;
 
         // Dependencies are compiled first.
-        let compiled_dependency_modules = self.compile_dependencies()?;
+        let _ = self.compile_dependencies()?;
 
         // We reset the warning count as we don't want to fail the build if a
         // dependency has warnings, only if the root package does.
@@ -234,7 +223,6 @@ where
         Ok(Built {
             root_package,
             module_interfaces: self.importable_modules,
-            compiled_dependency_modules,
         })
     }
 
@@ -276,7 +264,7 @@ where
 
         if self.io.is_file(&path) {
             let previous = self.io.read(&path)?;
-            if &previous == &fingerprint {
+            if previous == fingerprint {
                 return Ok(());
             }
         }
@@ -346,11 +334,11 @@ where
         // packages into their own classes and then only mutate self after we no
         // longer need to have the package borrowed from self.packages.
         let package = self.packages.get(name).expect("Missing package").clone();
-        let result = match usable_build_tools(&package)?.as_slice() {
-            &[BuildTool::Gleam] => self.compile_gleam_dep_package(&package),
-            &[BuildTool::Rebar3] => self.compile_rebar3_dep_package(&package).map(|_| vec![]),
-            &[BuildTool::Mix] => self.compile_mix_dep_package(&package).map(|_| vec![]),
-            &[BuildTool::Mix, BuildTool::Rebar3] => self
+        let result = match *usable_build_tools(&package)?.as_slice() {
+            [BuildTool::Gleam] => self.compile_gleam_dep_package(&package),
+            [BuildTool::Rebar3] => self.compile_rebar3_dep_package(&package).map(|_| vec![]),
+            [BuildTool::Mix] => self.compile_mix_dep_package(&package).map(|_| vec![]),
+            [BuildTool::Mix, BuildTool::Rebar3] => self
                 .compile_mix_dep_package(&package)
                 .or_else(|_| self.compile_rebar3_dep_package(&package))
                 .map(|_| vec![]),
@@ -409,9 +397,6 @@ where
         self.telemetry.compiling_package(package_name);
 
         let package = self.paths.build_packages_package(package_name);
-        let build_packages = self.paths.build_directory_for_target(mode, target);
-        let ebins = self.paths.build_packages_ebins_glob(mode, target);
-        let rebar3_path = |path: &Utf8Path| format!("../{}", path);
 
         tracing::debug!("copying_package_to_build");
         self.io.mkdir(&package_build)?;
@@ -663,7 +648,7 @@ where
 
         // Compile project to Erlang or JavaScript source code
         compiler.compile(
-            &mut self.warnings,
+            &self.warnings,
             &mut self.importable_modules,
             &mut self.defined_modules,
             &mut self.stale_modules,
@@ -688,12 +673,7 @@ fn order_packages(packages: &HashMap<String, ManifestPackage>) -> Result<Vec<Eco
             // any bugged outcomes, though not any where the compiler is working correctly, so it's
             // mostly to aid debugging.
             .sorted_by(|a, b| a.name.cmp(&b.name))
-            .map(|package| {
-                (
-                    package.name.as_str().into(),
-                    package.requirements.iter().cloned().collect(),
-                )
-            })
+            .map(|package| (package.name.as_str().into(), package.requirements.to_vec()))
             .collect(),
     )
     .map_err(convert_deps_tree_error)
@@ -757,9 +737,5 @@ impl BitFlags {
         } else {
             self.bits &= !(1 << bit);
         }
-    }
-
-    fn get(&self, bit: u8) -> bool {
-        self.bits & (1 << bit) != 0
     }
 }

--- a/compiler-core/src/build/telemetry.rs
+++ b/compiler-core/src/build/telemetry.rs
@@ -6,10 +6,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::{
-    Warning,
-    manifest::{PackageChanges, Resolved},
-};
+use crate::manifest::PackageChanges;
 
 pub trait Telemetry: Debug {
     fn waiting_for_build_directory_lock(&self);
@@ -29,7 +26,7 @@ pub struct NullTelemetry;
 
 impl Telemetry for NullTelemetry {
     fn waiting_for_build_directory_lock(&self) {}
-    fn running(&self, name: &str) {}
+    fn running(&self, _name: &str) {}
     fn resolving_package_versions(&self) {}
     fn downloading_package(&self, _name: &str) {}
     fn compiled_package(&self, _duration: Duration) {}


### PR DESCRIPTION
Most of the fixes after dropping the allow directive were mechanical. Two that weren't:

- `gleam_core::build::package_compiler::Input` - the variants of the enum were wildly different in sizes; `New` was 640 bytes and `Cached` was 72 bytes according to rustc, and it suggested boxing `New` to cut that down.
- `gleam_core::build::package_compiler::CachedModule` - the `line_numbers` field was unused.
- `gleam_core::build::project_compiler::Built` - the `compiled_dependency_modules` field was unused, but the call that populated it was left for any side effects.