### PR TITLE
Moves shebangs (#!/..) to the top of the file for POSIX shell scripts…

### DIFF
--- a/bin/add-nightly-suffix-to-versions.sh
+++ b/bin/add-nightly-suffix-to-versions.sh
@@ -1,7 +1,7 @@
+#!/bin/sh
+
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2023 The Gleam contributors
-
-#!/bin/sh
 
 #
 # Add the `-nightly-YYYYMMDD` suffix the version of all Rust crates in the

--- a/compiler-cli/templates/erlang-shipment-entrypoint.sh
+++ b/compiler-cli/templates/erlang-shipment-entrypoint.sh
@@ -1,7 +1,8 @@
+#!/bin/sh
+
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2022 The Gleam contributors
 
-#!/bin/sh
 set -eu
 
 PACKAGE=$PACKAGE_NAME_FROM_GLEAM

--- a/test/assert/run_tests.sh
+++ b/test/assert/run_tests.sh
@@ -1,7 +1,7 @@
+#!/usr/bin/env sh
+
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2025 The Gleam contributors
-
-#/usr/bin/env sh
 
 set -eu
 

--- a/test/erlang_shipment_no_dev_deps/test.sh
+++ b/test/erlang_shipment_no_dev_deps/test.sh
@@ -1,7 +1,7 @@
+#!/bin/sh
+
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2026 The Gleam contributors
-
-#!/bin/sh
 
 set -eu
 

--- a/test/external_only_erlang/test.sh
+++ b/test/external_only_erlang/test.sh
@@ -1,7 +1,7 @@
+#!/bin/sh
+
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2024 The Gleam contributors
-
-#!/bin/sh
 
 set -eu
 

--- a/test/external_only_javascript/test.sh
+++ b/test/external_only_javascript/test.sh
@@ -1,7 +1,7 @@
+#!/bin/sh
+
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2024 The Gleam contributors
-
-#!/bin/sh
 
 set -eu
 

--- a/test/multi_namespace/test.sh
+++ b/test/multi_namespace/test.sh
@@ -1,7 +1,7 @@
+#!/bin/sh
+
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2024 The Gleam contributors
-
-#!/bin/sh
 
 set -eu
 

--- a/test/multi_namespace_not_top_level/test.sh
+++ b/test/multi_namespace_not_top_level/test.sh
@@ -1,7 +1,7 @@
+#!/bin/sh
+
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2024 The Gleam contributors
-
-#!/bin/sh
 
 # https://github.com/gleam-lang/gleam/pull/4445
 

--- a/test/project_git_deps_path/test.sh
+++ b/test/project_git_deps_path/test.sh
@@ -1,7 +1,7 @@
+#!/bin/sh
+
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2026 The Gleam contributors
-
-#!/bin/sh
 
 set -eu
 

--- a/test/publishing_default_main/test.sh
+++ b/test/publishing_default_main/test.sh
@@ -1,7 +1,7 @@
+#!/bin/sh
+
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2025 The Gleam contributors
-
-#!/bin/sh
 
 set -eu
 

--- a/test/publishing_default_readme/test.sh
+++ b/test/publishing_default_readme/test.sh
@@ -1,7 +1,7 @@
+#!/bin/sh
+
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2025 The Gleam contributors
-
-#!/bin/sh
 
 set -eu
 

--- a/test/publishing_empty_readme/test.sh
+++ b/test/publishing_empty_readme/test.sh
@@ -1,7 +1,7 @@
+#!/bin/sh
+
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2025 The Gleam contributors
-
-#!/bin/sh
 
 set -eu
 

--- a/test/publishing_no_readme/test.sh
+++ b/test/publishing_no_readme/test.sh
@@ -1,7 +1,7 @@
+#!/bin/sh
+
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2025 The Gleam contributors
-
-#!/bin/sh
 
 set -eu
 

--- a/test/publishing_priv_symlink_escape/test.sh
+++ b/test/publishing_priv_symlink_escape/test.sh
@@ -1,7 +1,7 @@
+#!/bin/sh
+
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2026 The Gleam contributors
-
-#!/bin/sh
 
 set -eu
 

--- a/test/publishing_src_symlink_escape/test.sh
+++ b/test/publishing_src_symlink_escape/test.sh
@@ -1,7 +1,7 @@
+#!/bin/sh
+
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2026 The Gleam contributors
-
-#!/bin/sh
 
 set -eu
 

--- a/test/root_package_not_compiled_when_running_dep/test.sh
+++ b/test/root_package_not_compiled_when_running_dep/test.sh
@@ -1,7 +1,7 @@
+#!/bin/sh
+
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2024 The Gleam contributors
-
-#!/bin/sh
 
 set -eu
 

--- a/test/running_modules/run_tests.sh
+++ b/test/running_modules/run_tests.sh
@@ -1,7 +1,7 @@
+#!/usr/bin/env sh
+
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2023 The Gleam contributors
-
-#/usr/bin/env sh
 
 set -eu
 


### PR DESCRIPTION
Replaces '#/usr/bin/env sh' by '#!/usr/bin/env sh'

Issue: #6073 

- [ ] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [ ] Tests have been added for new behaviour
- [ ] The changelog has been updated for any user-facing changes
