### PR TITLE
JS: fix two bugs with `echo`ing numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@
   numbers like `1.0e300`.
   ([Andrey Kozhev](https://github.com/ankddev))
 
+- Fixed a bug where the `echo` on the JavaScript target would incorrectly print
+  `NaN` and `Infinity`.
+  ([Andrey Kozhev](https://github.com/ankddev))
+
 ## v1.18.1 - 2026-08-01
 
 - Fixed a bug where the Erlang code generator would generate wrong code when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@
   copyright metadata to the generated POSIX entrypoint.
   ([John Downey](https://github.com/jtdowney))
 
+- Fixed a bug where the `echo` on the JavaScript target would incorrectly print
+  numbers like `1.0e300`.
+  ([Andrey Kozhev](https://github.com/ankddev))
+
 ## v1.18.1 - 2026-08-01
 
 - Fixed a bug where the Erlang code generator would generate wrong code when

--- a/compiler-core/templates/echo.mjs
+++ b/compiler-core/templates/echo.mjs
@@ -66,7 +66,7 @@ class Echo$Inspector {
     if (v === null) return "//js(null)";
     if (v === undefined) return "Nil";
     if (t === "string") return this.#string(v);
-    if (t === "bigint" || globalThis.Number.isInteger(v)) return v.toString();
+    if (t === "bigint" || globalThis.Number.isSafeInteger(v)) return v.toString();
     if (t === "number") return this.#float(v);
     if (v instanceof $UtfCodepoint) return this.#utfCodepoint(v);
     if (v instanceof $BitArray) return this.#bit_array(v);

--- a/compiler-core/templates/echo.mjs
+++ b/compiler-core/templates/echo.mjs
@@ -56,8 +56,8 @@ class Echo$Inspector {
       } else if (globalThis.Number.isInteger(float)) {
         return string + ".0"
       } else {
-        // For NaN and Infinity we return it as-is.
-        return string;
+        // For NaN and Infinity we return it as JS representation.
+        return "//js(" + string + ")";
       }
     }
   }

--- a/compiler-core/templates/echo.mjs
+++ b/compiler-core/templates/echo.mjs
@@ -53,8 +53,11 @@ class Echo$Inspector {
       const index = string.indexOf("e");
       if (index >= 0) {
         return string.slice(0, index) + ".0" + string.slice(index);
+      } else if (globalThis.Number.isInteger(float)) {
+        return string + ".0"
       } else {
-        return string + ".0";
+        // For NaN and Infinity we return it as-is.
+        return string;
       }
     }
   }

--- a/test-output/cases/echo_float/src/main.gleam
+++ b/test-output/cases/echo_float/src/main.gleam
@@ -5,4 +5,8 @@ pub fn main() {
   echo 1.0
   echo 2.1
   echo 11.11
+  echo 1.0e300
+  echo 1.5e300
+  echo 1.0e-300
+  echo 1.5e-300
 }

--- a/test-output/cases/echo_nan_infinity/gleam.toml
+++ b/test-output/cases/echo_nan_infinity/gleam.toml
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2024 The Gleam contributors
+
+name = "echo_nan_infinity"
+version = "1.0.0"

--- a/test-output/cases/echo_nan_infinity/src/main.gleam
+++ b/test-output/cases/echo_nan_infinity/src/main.gleam
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024 The Gleam contributors
+
+pub fn main() {
+  let infinity = 1.0e300 *. 1.0e300
+  echo infinity
+  echo infinity /. infinity
+}

--- a/test-output/src/tests/echo.rs
+++ b/test-output/src/tests/echo.rs
@@ -181,6 +181,11 @@ fn echo_float() {
 }
 
 #[test]
+fn echo_nan_infinity() {
+    assert_echo!(Target::JavaScript, "echo_nan_infinity");
+}
+
+#[test]
 fn echo_function() {
     assert_echo!("echo_function");
 }

--- a/test-output/src/tests/snapshots/test_output__tests__echo__erlang-echo_float.snap
+++ b/test-output/src/tests/snapshots/test_output__tests__echo__erlang-echo_float.snap
@@ -10,6 +10,10 @@ pub fn main() {
   echo 1.0
   echo 2.1
   echo 11.11
+  echo 1.0e300
+  echo 1.5e300
+  echo 1.0e-300
+  echo 1.5e-300
 }
 
 
@@ -20,3 +24,11 @@ pub fn main() {
 2.1
 [90msrc/main.gleam:7[39m
 11.11
+[90msrc/main.gleam:8[39m
+1.0e300
+[90msrc/main.gleam:9[39m
+1.5e300
+[90msrc/main.gleam:10[39m
+1.0e-300
+[90msrc/main.gleam:11[39m
+1.5e-300

--- a/test-output/src/tests/snapshots/test_output__tests__echo__javascript-echo_float.snap
+++ b/test-output/src/tests/snapshots/test_output__tests__echo__javascript-echo_float.snap
@@ -10,6 +10,10 @@ pub fn main() {
   echo 1.0
   echo 2.1
   echo 11.11
+  echo 1.0e300
+  echo 1.5e300
+  echo 1.0e-300
+  echo 1.5e-300
 }
 
 
@@ -20,3 +24,11 @@ pub fn main() {
 2.1
 [90msrc/main.gleam:7[39m
 11.11
+[90msrc/main.gleam:8[39m
+1.0e300
+[90msrc/main.gleam:9[39m
+1.5e300
+[90msrc/main.gleam:10[39m
+1.0e-300
+[90msrc/main.gleam:11[39m
+1.5e-300

--- a/test-output/src/tests/snapshots/test_output__tests__echo__javascript-echo_nan_infinity.snap
+++ b/test-output/src/tests/snapshots/test_output__tests__echo__javascript-echo_nan_infinity.snap
@@ -1,0 +1,20 @@
+---
+source: test-output/src/tests/echo.rs
+expression: output
+---
+--- main.gleam ----------------------
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2024 The Gleam contributors
+
+pub fn main() {
+  let infinity = 1.0e300 *. 1.0e300
+  echo infinity
+  echo infinity /. infinity
+}
+
+
+--- gleam run output ----------------
+[90msrc/main.gleam:6[39m
+Infinity
+[90msrc/main.gleam:7[39m
+NaN

--- a/test-output/src/tests/snapshots/test_output__tests__echo__javascript-echo_nan_infinity.snap
+++ b/test-output/src/tests/snapshots/test_output__tests__echo__javascript-echo_nan_infinity.snap
@@ -15,6 +15,6 @@ pub fn main() {
 
 --- gleam run output ----------------
 [90msrc/main.gleam:6[39m
-Infinity
+//js(Infinity)
 [90msrc/main.gleam:7[39m
-NaN
+//js(NaN)


### PR DESCRIPTION
* Closes #6076
* Closes #6071
***
- [ ] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes
