### PR TITLE
Fix underline span for function calls in constants

### DIFF
--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -3533,16 +3533,8 @@ where
 
                         match self.tok0 {
                             Some((_, Token::LeftParen, paren_end)) => {
-                                self.advance(); // pop the LeftParen
-                                let call_end = self.find_matching_paren();
-                                let call_end = if call_end == 0 { paren_end } else { call_end };
-                                parse_error(
-                                    ParseErrorType::UnexpectedFunction,
-                                    SrcSpan {
-                                        start,
-                                        end: call_end,
-                                    },
-                                )
+                                self.advance();
+                                self.function_call_in_constant(start, paren_end)
                             }
                             _ => Ok(Some(Constant::Var {
                                 location: SrcSpan { start, end },
@@ -3572,16 +3564,8 @@ where
 
                 match self.tok0 {
                     Some((_, Token::LeftParen, paren_end)) => {
-                        self.advance(); // pop the LeftParen
-                        let call_end = self.find_matching_paren();
-                        let call_end = if call_end == 0 { paren_end } else { call_end };
-                        parse_error(
-                            ParseErrorType::UnexpectedFunction,
-                            SrcSpan {
-                                start,
-                                end: call_end,
-                            },
-                        )
+                        self.advance();
+                        self.function_call_in_constant(start, paren_end)
                     }
                     _ => Ok(Some(Constant::Var {
                         location: SrcSpan { start, end },
@@ -4518,52 +4502,36 @@ functions are declared separately from types.";
         }
     }
 
-    // Scan ahead through the token stream to find the matching closing paren.
-    // Assumes the opening LeftParen has already been consumed by the caller.
-    // Returns the end position of ')' if found, or 0 if unmatched (EOF).
-    fn find_matching_paren(&mut self) -> u32 {
+    /// This function is to be called after seeing a `name(` in a constant
+    /// or guard clause expression. It returns an error, as functions
+    /// cannot be called in this context.
+    fn function_call_in_constant(
+        &mut self,
+        start: u32,
+        start_paren: u32,
+    ) -> Result<Option<Constant<()>>, ParseError> {
         let mut depth: i32 = 1;
 
-        let mut last_end = 0u32;
-        loop {
-            let tok = self.tok0.take();
-            match tok {
-                Some((_, Token::LeftParen, e)) => {
+        // Scan ahead through the token stream to find the matching closing paren.
+        // This can skip over invalid Gleam code as it doens't check anything but (),
+        // but it is good enough for the error message.
+        let end = loop {
+            match self.next_tok() {
+                Some((_, Token::LeftParen, _)) => {
                     depth += 1;
-                    last_end = e;
-                    self.tok0 = self.tok1.take();
-                    match self.tokens.next() {
-                        Some(Ok(t)) => self.tok1 = Some(t),
-                        _ => self.tok1 = None,
-                    }
                 }
-                Some((_, Token::RightParen, e)) => {
+                Some((_, Token::RightParen, position)) if depth == 1 => {
+                    break position;
+                }
+                Some((_, Token::RightParen, _)) => {
                     depth -= 1;
-                    last_end = e;
-                    if depth == 0 {
-                        break;
-                    }
-                    self.tok0 = self.tok1.take();
-                    match self.tokens.next() {
-                        Some(Ok(t)) => self.tok1 = Some(t),
-                        _ => self.tok1 = None,
-                    }
                 }
-                Some(_) => {
-                    self.tok0 = self.tok1.take();
-                    match self.tokens.next() {
-                        Some(Ok(t)) => self.tok1 = Some(t),
-                        _ => self.tok1 = None,
-                    }
-                }
-                None => break,
+                Some(_) => (),
+                None => break start_paren,
             }
-        }
+        };
 
-        // Note: we leave the parser state somewhat disrupted here,
-        // but since this is called right before parse_error (which
-        // returns Err immediately), it doesn't matter.
-        last_end
+        parse_error(ParseErrorType::UnexpectedFunction, SrcSpan { start, end })
     }
 
     // Moves the token stream forward

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -3534,10 +3534,7 @@ where
                         match self.tok0 {
                             Some((_, Token::LeftParen, _)) => parse_error(
                                 ParseErrorType::UnexpectedFunction,
-                                SrcSpan {
-                                    start,
-                                    end: end + 1,
-                                },
+                                SrcSpan { start, end },
                             ),
                             _ => Ok(Some(Constant::Var {
                                 location: SrcSpan { start, end },
@@ -3568,10 +3565,7 @@ where
                 match self.tok0 {
                     Some((_, Token::LeftParen, _)) => parse_error(
                         ParseErrorType::UnexpectedFunction,
-                        SrcSpan {
-                            start,
-                            end: end + 1,
-                        },
+                        SrcSpan { start, end },
                     ),
                     _ => Ok(Some(Constant::Var {
                         location: SrcSpan { start, end },

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -3532,10 +3532,13 @@ where
                         self.advance(); // name
 
                         match self.tok0 {
-                            Some((_, Token::LeftParen, _)) => parse_error(
-                                ParseErrorType::UnexpectedFunction,
-                                SrcSpan { start, end },
-                            ),
+                            Some((_, Token::LeftParen, _)) => {
+                                let call_end = self.find_matching_paren();
+                                parse_error(
+                                    ParseErrorType::UnexpectedFunction,
+                                    SrcSpan { start, end: call_end },
+                                )
+                            }
                             _ => Ok(Some(Constant::Var {
                                 location: SrcSpan { start, end },
                                 module: Some((name, SrcSpan::new(start, module_end))),
@@ -3563,10 +3566,14 @@ where
                 self.advance(); // name
 
                 match self.tok0 {
-                    Some((_, Token::LeftParen, _)) => parse_error(
-                        ParseErrorType::UnexpectedFunction,
-                        SrcSpan { start, end },
-                    ),
+                    Some((_, Token::LeftParen, _)) => {
+                        // Scan ahead to find the matching closing paren
+                        let call_end = self.find_matching_paren();
+                        parse_error(
+                            ParseErrorType::UnexpectedFunction,
+                            SrcSpan { start, end: call_end },
+                        )
+                    }
                     _ => Ok(Some(Constant::Var {
                         location: SrcSpan { start, end },
                         module: None,
@@ -4500,6 +4507,62 @@ functions are declared separately from types.";
                 SrcSpan { start, end },
             ),
         }
+    }
+
+    // Scan ahead through the token stream to find the matching closing paren
+    // for the current LeftParen in tok0. Returns the end position of ')'.
+    // Does not consume any tokens - uses the underlying lexer iterator directly.
+    fn find_matching_paren(&mut self) -> u32 {
+        let mut depth: i32 = 1;
+        let mut saved_tok1 = self.tok1.take();
+
+        // tok0 is currently LeftParen, advance past it
+        self.tok0 = saved_tok1.take();
+        match self.tokens.next() {
+            Some(Ok(tok)) => self.tok1 = Some(tok),
+            _ => self.tok1 = None,
+        }
+
+        let mut last_end = 0u32;
+        loop {
+            let tok = self.tok0.take();
+            match tok {
+                Some((_, Token::LeftParen, e)) => {
+                    depth += 1;
+                    last_end = e;
+                    self.tok0 = self.tok1.take();
+                    match self.tokens.next() {
+                        Some(Ok(t)) => self.tok1 = Some(t),
+                        _ => self.tok1 = None,
+                    }
+                }
+                Some((_, Token::RightParen, e)) => {
+                    depth -= 1;
+                    last_end = e;
+                    if depth == 0 {
+                        break;
+                    }
+                    self.tok0 = self.tok1.take();
+                    match self.tokens.next() {
+                        Some(Ok(t)) => self.tok1 = Some(t),
+                        _ => self.tok1 = None,
+                    }
+                }
+                Some(_) => {
+                    self.tok0 = self.tok1.take();
+                    match self.tokens.next() {
+                        Some(Ok(t)) => self.tok1 = Some(t),
+                        _ => self.tok1 = None,
+                    }
+                }
+                None => break,
+            }
+        }
+
+        // Note: we leave the parser state somewhat disrupted here,
+        // but since this is called right before parse_error (which
+        // returns Err immediately), it doesn't matter.
+        last_end
     }
 
     // Moves the token stream forward

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -3532,8 +3532,14 @@ where
                         self.advance(); // name
 
                         match self.tok0 {
-                            Some((_, Token::LeftParen, _)) => {
+                            Some((_, Token::LeftParen, paren_end)) => {
+                                self.advance(); // pop the LeftParen
                                 let call_end = self.find_matching_paren();
+                                let call_end = if call_end == 0 {
+                                    paren_end
+                                } else {
+                                    call_end
+                                };
                                 parse_error(
                                     ParseErrorType::UnexpectedFunction,
                                     SrcSpan { start, end: call_end },
@@ -3566,9 +3572,14 @@ where
                 self.advance(); // name
 
                 match self.tok0 {
-                    Some((_, Token::LeftParen, _)) => {
-                        // Scan ahead to find the matching closing paren
+                    Some((_, Token::LeftParen, paren_end)) => {
+                        self.advance(); // pop the LeftParen
                         let call_end = self.find_matching_paren();
+                        let call_end = if call_end == 0 {
+                            paren_end
+                        } else {
+                            call_end
+                        };
                         parse_error(
                             ParseErrorType::UnexpectedFunction,
                             SrcSpan { start, end: call_end },
@@ -4509,19 +4520,11 @@ functions are declared separately from types.";
         }
     }
 
-    // Scan ahead through the token stream to find the matching closing paren
-    // for the current LeftParen in tok0. Returns the end position of ')'.
-    // Does not consume any tokens - uses the underlying lexer iterator directly.
+    // Scan ahead through the token stream to find the matching closing paren.
+    // Assumes the opening LeftParen has already been consumed by the caller.
+    // Returns the end position of ')' if found, or 0 if unmatched (EOF).
     fn find_matching_paren(&mut self) -> u32 {
         let mut depth: i32 = 1;
-        let mut saved_tok1 = self.tok1.take();
-
-        // tok0 is currently LeftParen, advance past it
-        self.tok0 = saved_tok1.take();
-        match self.tokens.next() {
-            Some(Ok(tok)) => self.tok1 = Some(tok),
-            _ => self.tok1 = None,
-        }
 
         let mut last_end = 0u32;
         loop {

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -3535,14 +3535,13 @@ where
                             Some((_, Token::LeftParen, paren_end)) => {
                                 self.advance(); // pop the LeftParen
                                 let call_end = self.find_matching_paren();
-                                let call_end = if call_end == 0 {
-                                    paren_end
-                                } else {
-                                    call_end
-                                };
+                                let call_end = if call_end == 0 { paren_end } else { call_end };
                                 parse_error(
                                     ParseErrorType::UnexpectedFunction,
-                                    SrcSpan { start, end: call_end },
+                                    SrcSpan {
+                                        start,
+                                        end: call_end,
+                                    },
                                 )
                             }
                             _ => Ok(Some(Constant::Var {
@@ -3575,14 +3574,13 @@ where
                     Some((_, Token::LeftParen, paren_end)) => {
                         self.advance(); // pop the LeftParen
                         let call_end = self.find_matching_paren();
-                        let call_end = if call_end == 0 {
-                            paren_end
-                        } else {
-                            call_end
-                        };
+                        let call_end = if call_end == 0 { paren_end } else { call_end };
                         parse_error(
                             ParseErrorType::UnexpectedFunction,
-                            SrcSpan { start, end: call_end },
+                            SrcSpan {
+                                start,
+                                end: call_end,
+                            },
                         )
                     }
                     _ => Ok(Some(Constant::Var {

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__calling_module_constant_as_constructor.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__calling_module_constant_as_constructor.snap
@@ -14,4 +14,4 @@ error: Syntax error
   ┌─ /src/parse/error.gleam:4:15
   │
 4 │ pub const a = wibble(1)
-  │               ^^^^^^^ Functions can only be called within other functions
+  │               ^^^^^^ Functions can only be called within other functions

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__calling_module_constant_as_constructor.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__calling_module_constant_as_constructor.snap
@@ -14,4 +14,4 @@ error: Syntax error
   ┌─ /src/parse/error.gleam:4:15
   │
 4 │ pub const a = wibble(1)
-  │               ^^^^^^ Functions can only be called within other functions
+  │               ^^^^^^^^^ Functions can only be called within other functions

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_with_function_call.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_with_function_call.snap
@@ -13,4 +13,4 @@ error: Syntax error
   ┌─ /src/parse/error.gleam:3:18
   │
 3 │ const wib: Int = wibble()
-  │                  ^^^^^^^ Functions can only be called within other functions
+  │                  ^^^^^^ Functions can only be called within other functions

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_with_function_call.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_with_function_call.snap
@@ -13,4 +13,4 @@ error: Syntax error
   ┌─ /src/parse/error.gleam:3:18
   │
 3 │ const wib: Int = wibble()
-  │                  ^^^^^^ Functions can only be called within other functions
+  │                  ^^^^^^^^ Functions can only be called within other functions

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_with_function_call_with_args.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_with_function_call_with_args.snap
@@ -13,4 +13,4 @@ error: Syntax error
   ┌─ /src/parse/error.gleam:3:18
   │
 3 │ const wib: Int = wibble(1, "wobble")
-  │                  ^^^^^^^ Functions can only be called within other functions
+  │                  ^^^^^^ Functions can only be called within other functions

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_with_function_call_with_args.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_with_function_call_with_args.snap
@@ -13,4 +13,4 @@ error: Syntax error
   ┌─ /src/parse/error.gleam:3:18
   │
 3 │ const wib: Int = wibble(1, "wobble")
-  │                  ^^^^^^ Functions can only be called within other functions
+  │                  ^^^^^^^^^^^^^^^^^^^ Functions can only be called within other functions

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__functions_called_outside_module.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__functions_called_outside_module.snap
@@ -10,4 +10,4 @@ error: Syntax error
   ┌─ /src/one/two.gleam:1:15
   │
 1 │ const first = list.at([1], 0)
-  │               ^^^^^^^ Functions can only be called within other functions
+  │               ^^^^^^^^^^^^^^^ Functions can only be called within other functions

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__functions_called_outside_module.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__functions_called_outside_module.snap
@@ -10,4 +10,4 @@ error: Syntax error
   ┌─ /src/one/two.gleam:1:15
   │
 1 │ const first = list.at([1], 0)
-  │               ^^^^^^^^ Functions can only be called within other functions
+  │               ^^^^^^^ Functions can only be called within other functions


### PR DESCRIPTION
The diagnostic underline for function calls in const definitions previously included the opening parenthesis, producing something like:

```
3 │ const wib: Int = wibble()
  │                  ^^^^^^^ Functions can only be called within other functions
```

Now it only highlights the function name:

```
3 │ const wib: Int = wibble()
  │                  ^^^^^^ Functions can only be called within other functions
\```

Closes #6053