### PR TITLE
Drop copyright notice from POSIX entrypoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,7 @@
 - Fixed a bug where on the JavaScript target a case clause whose guard's top
   level operator was `||` could run for a subject its pattern did not match.
   ([John Downey](https://github.com/jtdowney))
+
+- Fixed a bug where `gleam export erlang-shipment` would add Gleam contributor
+  copyright metadata to the generated POSIX entrypoint.
+  ([John Downey](https://github.com/jtdowney))

--- a/compiler-cli/templates/erlang-shipment-entrypoint.sh
+++ b/compiler-cli/templates/erlang-shipment-entrypoint.sh
@@ -1,8 +1,5 @@
 #!/bin/sh
 
-# SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: 2022 The Gleam contributors
-
 set -eu
 
 PACKAGE=$PACKAGE_NAME_FROM_GLEAM


### PR DESCRIPTION
Closes #6090

- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [ ] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes
