### PR TITLE
erl: fix miscompilation of some consts in bit arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,3 +50,8 @@
 - Fixed a bug where `gleam export erlang-shipment` would add Gleam contributor
   copyright metadata to the generated POSIX entrypoint.
   ([John Downey](https://github.com/jtdowney))
+
+- Fixed a bug where the Erlang code generator would generate wrong code when
+  referencing constants that are aliases to other constants in bit array
+  segments, string concatenation and clause guards.
+  ([Andrey Kozhev](https://github.com/ankddev))

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -3362,33 +3362,25 @@ fn type_export(custom_type: &TypedCustomType) -> (EcoString, usize) {
 
 /// This returns true if the given expression is going to be compiled to a
 /// single literal Erlang string.
-/// This is not true just for literal Gleam strings like `"abc"`, but also
+/// This is not only true for literal Gleam strings like `"abc"`, but also for
 /// variables referencing string constants (as those are inlined)
 fn produces_literal_string(value: &TypedExpr) -> bool {
     match value {
-        TypedExpr::String { .. }
+        TypedExpr::String { .. } => true,
         // Constants are inlined on the Erlang target, so we need to check if
-        // those are literal strings too!
-        | TypedExpr::ModuleSelect {
-            constructor:
-                ModuleValueConstructor::Constant {
-                    literal: Constant::String { .. },
-                    ..
-                },
+        // those produce literal strings too!
+        TypedExpr::ModuleSelect {
+            constructor: ModuleValueConstructor::Constant { literal, .. },
             ..
         }
         | TypedExpr::Var {
             constructor:
                 ValueConstructor {
-                    variant:
-                        ValueConstructorVariant::ModuleConstant {
-                            literal: Constant::String { .. },
-                            ..
-                        },
+                    variant: ValueConstructorVariant::ModuleConstant { literal, .. },
                     ..
                 },
             ..
-        } => true,
+        } => constant_produces_literal_string(literal),
 
         TypedExpr::Int { .. }
         | TypedExpr::Var { .. }
@@ -3416,23 +3408,51 @@ fn produces_literal_string(value: &TypedExpr) -> bool {
     }
 }
 
-/// This returns true if the given expression is going to be compiled to a
+/// This returns true if the given constant is going to be compiled to a
 /// single literal Erlang string.
-/// This is not true just for literal Gleam strings like `"abc"`, but also
+/// This is not only true for literal Gleam strings like `"abc"`, but also for
+/// variables referencing string constants (as those are inlined)
+fn constant_produces_literal_string(constant: &Constant<Arc<Type>>) -> bool {
+    match constant {
+        Constant::String { .. } => true,
+        Constant::Var {
+            constructor: Some(constructor),
+            ..
+        } if let ValueConstructor {
+            variant: ValueConstructorVariant::ModuleConstant { ref literal, .. },
+            ..
+        } = **constructor =>
+        {
+            constant_produces_literal_string(literal)
+        }
+        Constant::Int { .. }
+        | Constant::Float { .. }
+        | Constant::Tuple { .. }
+        | Constant::List { .. }
+        | Constant::Record { .. }
+        | Constant::RecordUpdate { .. }
+        | Constant::BitArray { .. }
+        | Constant::StringConcatenation { .. }
+        | Constant::Invalid { .. }
+        | Constant::Todo { .. }
+        | Constant::Var { .. } => false,
+    }
+}
+
+/// This returns true if the given guard is going to be compiled to a
+/// single literal Erlang string.
+/// This is not only true for literal Gleam strings like `"abc"`, but also for
 /// variables referencing string constants (as those are inlined)
 fn guard_produces_literal_string(guard: &ClauseGuard<Arc<Type>>) -> bool {
     match guard {
         ClauseGuard::Block { value, .. } => guard_produces_literal_string(value),
 
         ClauseGuard::ModuleSelect {
-            literal: Constant::String { .. },
-            ..
+            literal: constant, ..
         }
-        | ClauseGuard::Constant(Constant::String { .. }) => true,
+        | ClauseGuard::Constant(constant) => constant_produces_literal_string(constant),
 
         ClauseGuard::BinaryOperator { .. }
-        | ClauseGuard::Constant(..)
-        | ClauseGuard::ModuleSelect { .. }
         | ClauseGuard::Not { .. }
         | ClauseGuard::Var { .. }
         | ClauseGuard::TupleIndex { .. }

--- a/compiler-core/src/erlang/tests/consts.rs
+++ b/compiler-core/src/erlang/tests/consts.rs
@@ -308,3 +308,199 @@ pub fn main() {
 "#
     )
 }
+
+// https://github.com/gleam-lang/gleam/issues/6086
+#[test]
+fn constant_imported_aliased_string_in_bit_array_segment_test_with_utf16_option() {
+    assert_erl!(
+        (
+            "some_module",
+            "some_module",
+            r#"
+pub const wibble = "a"
+            "#
+        ),
+        r#"
+import some_module.{wibble}
+
+const wobble = wibble
+
+pub fn main() {
+  let _ = <<wobble:utf16>>
+  Nil
+}
+"#
+    )
+}
+
+// https://github.com/gleam-lang/gleam/issues/6086
+#[test]
+fn constant_imported_aliased_string_in_bit_array_segment_test_with_utf16_option_2() {
+    assert_erl!(
+        (
+            "some_module",
+            "some_module",
+            r#"
+pub const wibble = "a"
+            "#
+        ),
+        r#"
+import some_module
+
+const wobble = some_module.wibble
+const wubble = wobble
+
+pub fn main() {
+  let _ = <<wubble:utf16>>
+  Nil
+}
+"#
+    )
+}
+
+// https://github.com/gleam-lang/gleam/issues/6086
+#[test]
+fn constant_imported_aliased_string_in_bit_array_segment_test_with_utf8_option() {
+    assert_erl!(
+        (
+            "some_module",
+            "some_module",
+            r#"
+pub const wibble = "a"
+            "#
+        ),
+        r#"
+import some_module.{wibble}
+
+const wobble = wibble
+
+pub fn main() {
+  let _ = <<wobble:utf8>>
+  Nil
+}
+"#
+    )
+}
+
+// https://github.com/gleam-lang/gleam/issues/6086
+#[test]
+fn constant_imported_aliased_string_in_bit_array_segment_test_with_utf8_option_2() {
+    assert_erl!(
+        (
+            "some_module",
+            "some_module",
+            r#"
+pub const wibble = "a"
+            "#
+        ),
+        r#"
+import some_module
+
+const wobble = some_module.wibble
+const wubble = wobble
+
+pub fn main() {
+  let _ = <<wubble:utf8>>
+  Nil
+}
+"#
+    )
+}
+
+// https://github.com/gleam-lang/gleam/issues/6086
+#[test]
+fn constant_aliased_string_in_bit_array_segment_test_with_utf8_option() {
+    assert_erl!(
+        r#"
+const wibble = "a"
+const wobble = wibble
+
+pub fn main() {
+  let _ = <<wobble:utf8>>
+  Nil
+}
+"#
+    )
+}
+
+// https://github.com/gleam-lang/gleam/issues/6086
+#[test]
+fn constant_aliased_string_in_bit_array_segment_test_with_utf16_option() {
+    assert_erl!(
+        r#"
+const wibble = "a"
+const wobble = wibble
+
+pub fn main() {
+  let _ = <<wobble:utf16>>
+  Nil
+}
+"#
+    )
+}
+
+// https://github.com/gleam-lang/gleam/issues/6086
+#[test]
+fn constant_imported_aliased_string_in_string_concatenation() {
+    assert_erl!(
+        (
+            "some_module",
+            "some_module",
+            r#"
+pub const wibble = "a"
+            "#
+        ),
+        r#"
+import some_module
+
+const wobble = some_module.wibble
+const wubble = wobble
+
+pub fn main() {
+  let _ = wubble <> "b"
+}
+"#
+    )
+}
+
+// https://github.com/gleam-lang/gleam/issues/6086
+#[test]
+fn constant_imported_aliased_string_in_string_concatenation_in_guard() {
+    assert_erl!(
+        (
+            "some_module",
+            "some_module",
+            r#"
+pub const wibble = "a"
+            "#
+        ),
+        r#"
+import some_module
+
+const wobble = some_module.wibble
+const wubble = wobble
+
+pub fn go(x) {
+  case x {
+    x if x == wubble <> "b" -> todo
+    _ -> todo
+  }
+}
+"#
+    )
+}
+
+// https://github.com/gleam-lang/gleam/issues/6086
+#[test]
+fn constant_aliased_string_in_concatenation() {
+    assert_erl!(
+        r#"
+const wibble = "a"
+const wobble = wibble
+
+pub fn main() {
+  let _ = wobble <> "b"
+}
+"#
+    )
+}

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_aliased_string_in_bit_array_segment_test_with_utf16_option.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_aliased_string_in_bit_array_segment_test_with_utf16_option.snap
@@ -21,5 +21,5 @@ pub fn main() {
 -file("project/test/my/mod.gleam", 5).
 -spec main() -> nil.
 main() ->
-    _ = <<(unicode:characters_to_binary(~"a", utf8, {utf16, big}))/binary>>,
+    _ = <<"a"/utf16>>,
     nil.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_aliased_string_in_bit_array_segment_test_with_utf16_option.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_aliased_string_in_bit_array_segment_test_with_utf16_option.snap
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/erlang/tests/consts.rs
+expression: "\nconst wibble = \"a\"\nconst wobble = wibble\n\npub fn main() {\n  let _ = <<wobble:utf16>>\n  Nil\n}\n"
+---
+----- SOURCE CODE
+
+const wibble = "a"
+const wobble = wibble
+
+pub fn main() {
+  let _ = <<wobble:utf16>>
+  Nil
+}
+
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_ignored, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
+-export([main/0]).
+
+-file("project/test/my/mod.gleam", 5).
+-spec main() -> nil.
+main() ->
+    _ = <<(unicode:characters_to_binary(~"a", utf8, {utf16, big}))/binary>>,
+    nil.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_aliased_string_in_bit_array_segment_test_with_utf8_option.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_aliased_string_in_bit_array_segment_test_with_utf8_option.snap
@@ -21,5 +21,5 @@ pub fn main() {
 -file("project/test/my/mod.gleam", 5).
 -spec main() -> nil.
 main() ->
-    _ = <<"a"/binary>>,
+    _ = <<"a"/utf8>>,
     nil.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_aliased_string_in_bit_array_segment_test_with_utf8_option.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_aliased_string_in_bit_array_segment_test_with_utf8_option.snap
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/erlang/tests/consts.rs
+expression: "\nconst wibble = \"a\"\nconst wobble = wibble\n\npub fn main() {\n  let _ = <<wobble:utf8>>\n  Nil\n}\n"
+---
+----- SOURCE CODE
+
+const wibble = "a"
+const wobble = wibble
+
+pub fn main() {
+  let _ = <<wobble:utf8>>
+  Nil
+}
+
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_ignored, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
+-export([main/0]).
+
+-file("project/test/my/mod.gleam", 5).
+-spec main() -> nil.
+main() ->
+    _ = <<"a"/binary>>,
+    nil.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_aliased_string_in_concatenation.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_aliased_string_in_concatenation.snap
@@ -1,0 +1,23 @@
+---
+source: compiler-core/src/erlang/tests/consts.rs
+expression: "\nconst wibble = \"a\"\nconst wobble = wibble\n\npub fn main() {\n  let _ = wobble <> \"b\"\n}\n"
+---
+----- SOURCE CODE
+
+const wibble = "a"
+const wobble = wibble
+
+pub fn main() {
+  let _ = wobble <> "b"
+}
+
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_ignored, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
+-export([main/0]).
+
+-file("project/test/my/mod.gleam", 5).
+-spec main() -> binary().
+main() ->
+    _ = <<"a"/binary, "b"/utf8>>.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_aliased_string_in_concatenation.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_aliased_string_in_concatenation.snap
@@ -20,4 +20,4 @@ pub fn main() {
 -file("project/test/my/mod.gleam", 5).
 -spec main() -> binary().
 main() ->
-    _ = <<"a"/binary, "b"/utf8>>.
+    _ = <<"a"/utf8, "b"/utf8>>.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_imported_aliased_string_in_bit_array_segment_test_with_utf16_option.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_imported_aliased_string_in_bit_array_segment_test_with_utf16_option.snap
@@ -1,0 +1,26 @@
+---
+source: compiler-core/src/erlang/tests/consts.rs
+expression: "\nimport some_module.{wibble}\n\nconst wobble = wibble\n\npub fn main() {\n  let _ = <<wobble:utf16>>\n  Nil\n}\n"
+---
+----- SOURCE CODE
+
+import some_module.{wibble}
+
+const wobble = wibble
+
+pub fn main() {
+  let _ = <<wobble:utf16>>
+  Nil
+}
+
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_ignored, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
+-export([main/0]).
+
+-file("project/test/my/mod.gleam", 6).
+-spec main() -> nil.
+main() ->
+    _ = <<(unicode:characters_to_binary(~"a", utf8, {utf16, big}))/binary>>,
+    nil.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_imported_aliased_string_in_bit_array_segment_test_with_utf16_option.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_imported_aliased_string_in_bit_array_segment_test_with_utf16_option.snap
@@ -22,5 +22,5 @@ pub fn main() {
 -file("project/test/my/mod.gleam", 6).
 -spec main() -> nil.
 main() ->
-    _ = <<(unicode:characters_to_binary(~"a", utf8, {utf16, big}))/binary>>,
+    _ = <<"a"/utf16>>,
     nil.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_imported_aliased_string_in_bit_array_segment_test_with_utf16_option_2.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_imported_aliased_string_in_bit_array_segment_test_with_utf16_option_2.snap
@@ -1,0 +1,27 @@
+---
+source: compiler-core/src/erlang/tests/consts.rs
+expression: "\nimport some_module\n\nconst wobble = some_module.wibble\nconst wubble = wobble\n\npub fn main() {\n  let _ = <<wubble:utf16>>\n  Nil\n}\n"
+---
+----- SOURCE CODE
+
+import some_module
+
+const wobble = some_module.wibble
+const wubble = wobble
+
+pub fn main() {
+  let _ = <<wubble:utf16>>
+  Nil
+}
+
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_ignored, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
+-export([main/0]).
+
+-file("project/test/my/mod.gleam", 7).
+-spec main() -> nil.
+main() ->
+    _ = <<(unicode:characters_to_binary(~"a", utf8, {utf16, big}))/binary>>,
+    nil.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_imported_aliased_string_in_bit_array_segment_test_with_utf16_option_2.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_imported_aliased_string_in_bit_array_segment_test_with_utf16_option_2.snap
@@ -23,5 +23,5 @@ pub fn main() {
 -file("project/test/my/mod.gleam", 7).
 -spec main() -> nil.
 main() ->
-    _ = <<(unicode:characters_to_binary(~"a", utf8, {utf16, big}))/binary>>,
+    _ = <<"a"/utf16>>,
     nil.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_imported_aliased_string_in_bit_array_segment_test_with_utf8_option.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_imported_aliased_string_in_bit_array_segment_test_with_utf8_option.snap
@@ -1,0 +1,26 @@
+---
+source: compiler-core/src/erlang/tests/consts.rs
+expression: "\nimport some_module.{wibble}\n\nconst wobble = wibble\n\npub fn main() {\n  let _ = <<wobble:utf8>>\n  Nil\n}\n"
+---
+----- SOURCE CODE
+
+import some_module.{wibble}
+
+const wobble = wibble
+
+pub fn main() {
+  let _ = <<wobble:utf8>>
+  Nil
+}
+
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_ignored, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
+-export([main/0]).
+
+-file("project/test/my/mod.gleam", 6).
+-spec main() -> nil.
+main() ->
+    _ = <<"a"/binary>>,
+    nil.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_imported_aliased_string_in_bit_array_segment_test_with_utf8_option.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_imported_aliased_string_in_bit_array_segment_test_with_utf8_option.snap
@@ -22,5 +22,5 @@ pub fn main() {
 -file("project/test/my/mod.gleam", 6).
 -spec main() -> nil.
 main() ->
-    _ = <<"a"/binary>>,
+    _ = <<"a"/utf8>>,
     nil.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_imported_aliased_string_in_bit_array_segment_test_with_utf8_option_2.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_imported_aliased_string_in_bit_array_segment_test_with_utf8_option_2.snap
@@ -23,5 +23,5 @@ pub fn main() {
 -file("project/test/my/mod.gleam", 7).
 -spec main() -> nil.
 main() ->
-    _ = <<"a"/binary>>,
+    _ = <<"a"/utf8>>,
     nil.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_imported_aliased_string_in_bit_array_segment_test_with_utf8_option_2.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_imported_aliased_string_in_bit_array_segment_test_with_utf8_option_2.snap
@@ -1,0 +1,27 @@
+---
+source: compiler-core/src/erlang/tests/consts.rs
+expression: "\nimport some_module\n\nconst wobble = some_module.wibble\nconst wubble = wobble\n\npub fn main() {\n  let _ = <<wubble:utf8>>\n  Nil\n}\n"
+---
+----- SOURCE CODE
+
+import some_module
+
+const wobble = some_module.wibble
+const wubble = wobble
+
+pub fn main() {
+  let _ = <<wubble:utf8>>
+  Nil
+}
+
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_ignored, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
+-export([main/0]).
+
+-file("project/test/my/mod.gleam", 7).
+-spec main() -> nil.
+main() ->
+    _ = <<"a"/binary>>,
+    nil.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_imported_aliased_string_in_string_concatenation.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_imported_aliased_string_in_string_concatenation.snap
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/erlang/tests/consts.rs
+expression: "\nimport some_module\n\nconst wobble = some_module.wibble\nconst wubble = wobble\n\npub fn main() {\n  let _ = wubble <> \"b\"\n}\n"
+---
+----- SOURCE CODE
+
+import some_module
+
+const wobble = some_module.wibble
+const wubble = wobble
+
+pub fn main() {
+  let _ = wubble <> "b"
+}
+
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_ignored, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
+-export([main/0]).
+
+-file("project/test/my/mod.gleam", 7).
+-spec main() -> binary().
+main() ->
+    _ = <<"a"/binary, "b"/utf8>>.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_imported_aliased_string_in_string_concatenation.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_imported_aliased_string_in_string_concatenation.snap
@@ -22,4 +22,4 @@ pub fn main() {
 -file("project/test/my/mod.gleam", 7).
 -spec main() -> binary().
 main() ->
-    _ = <<"a"/binary, "b"/utf8>>.
+    _ = <<"a"/utf8, "b"/utf8>>.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_imported_aliased_string_in_string_concatenation_in_guard.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_imported_aliased_string_in_string_concatenation_in_guard.snap
@@ -1,0 +1,48 @@
+---
+source: compiler-core/src/erlang/tests/consts.rs
+expression: "\nimport some_module\n\nconst wobble = some_module.wibble\nconst wubble = wobble\n\npub fn go(x) {\n  case x {\n    x if x == wubble <> \"b\" -> todo\n    _ -> todo\n  }\n}\n"
+---
+----- SOURCE CODE
+
+import some_module
+
+const wobble = some_module.wibble
+const wubble = wobble
+
+pub fn go(x) {
+  case x {
+    x if x == wubble <> "b" -> todo
+    _ -> todo
+  }
+}
+
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_ignored, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
+-export([go/1]).
+
+-file("project/test/my/mod.gleam", 7).
+-spec go(binary()) -> any().
+go(X) ->
+    case X of
+        X@1 when X@1 =:= <<"a"/binary, "b"/utf8>> ->
+            erlang:error(#{
+                gleam_error => todo,
+                message => ~"`todo` expression evaluated. This code has not yet been implemented.",
+                file => ~"project/test/my/mod.gleam",
+                module => ~"my/mod",
+                function => ~"go",
+                line => 9
+            });
+
+        _ ->
+            erlang:error(#{
+                gleam_error => todo,
+                message => ~"`todo` expression evaluated. This code has not yet been implemented.",
+                file => ~"project/test/my/mod.gleam",
+                module => ~"my/mod",
+                function => ~"go",
+                line => 10
+            })
+    end.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_imported_aliased_string_in_string_concatenation_in_guard.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_imported_aliased_string_in_string_concatenation_in_guard.snap
@@ -26,7 +26,7 @@ pub fn go(x) {
 -spec go(binary()) -> any().
 go(X) ->
     case X of
-        X@1 when X@1 =:= <<"a"/binary, "b"/utf8>> ->
+        X@1 when X@1 =:= <<"a"/utf8, "b"/utf8>> ->
             erlang:error(#{
                 gleam_error => todo,
                 message => ~"`todo` expression evaluated. This code has not yet been implemented.",

--- a/test/language/test/language/constant_test.gleam
+++ b/test/language/test/language/constant_test.gleam
@@ -56,3 +56,20 @@ pub fn constant_string_in_bit_array_segment_test() {
   assert <<"hello">> == <<message:utf8>>
   assert <<"hello":utf8>> == <<message:utf8>>
 }
+
+const message_2 = message
+
+const message_3 = message_2 <> "?"
+
+// https://github.com/gleam-lang/gleam/issues/6086
+pub fn constant_aliased_string_in_bit_arrays_test() {
+  assert <<"hello">> == <<message_2:utf8>>
+  assert <<"hello":utf8>> == <<message_2:utf8>>
+  assert "hello!" == message_2 <> "!"
+  assert "hello?!" == message_3 <> "!"
+  let subject = "hello!"
+  assert case subject {
+    wibble if wibble == message_2 <> "!" -> True
+    _ -> False
+  }
+}


### PR DESCRIPTION
* Closes #6086 
* It also fixes similar bug in clause guards
***
- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes
