### PR TITLE
language test: add few missing `_test`s

### DIFF
--- a/test/language/test/language/bit_array_match_test.gleam
+++ b/test/language/test/language/bit_array_match_test.gleam
@@ -144,12 +144,12 @@ pub fn multiple_variable_segments_test() {
 }
 
 // https://github.com/gleam-lang/gleam/issues/5208
-pub fn unit_ignores_bytes_option() {
+pub fn unit_ignores_bytes_option_test() {
   let assert <<x:unit(2)-bytes-size(3)>> = <<1:6>>
   assert x == <<1:6>>
 }
 
-pub fn unit_ignores_bytes_option_regardless_of_order() {
+pub fn unit_ignores_bytes_option_regardless_of_order_test() {
   let assert <<x:bytes-unit(2)-size(3)>> = <<1:6>>
   assert x == <<1:6>>
 }

--- a/test/language/test/language/bool_negation_test.gleam
+++ b/test/language/test/language/bool_negation_test.gleam
@@ -21,7 +21,7 @@ pub fn negation_false_or_panic_test() {
   bool || panic
 }
 
-pub fn negation_correctly_parenthesised() {
+pub fn negation_correctly_parenthesised_test() {
   let bool = !{ True || False }
   assert !bool
 }

--- a/test/language/test/language/constant_test.gleam
+++ b/test/language/test/language/constant_test.gleam
@@ -52,7 +52,7 @@ pub fn list_2_test() {
 const message = "hello"
 
 // https://github.com/gleam-lang/gleam/issues/6045
-pub fn constant_string_in_bit_array_segment() {
+pub fn constant_string_in_bit_array_segment_test() {
   assert <<"hello">> == <<message:utf8>>
   assert <<"hello":utf8>> == <<message:utf8>>
 }


### PR DESCRIPTION
I noticed that few language tests didn't have `_test` at the end, meaning they didn't run when running test suite. This PR fixes this.
***
- [ ] The changes in this PR have been discussed beforehand in an issue
- [ ] The issue for this PR has been linked
- [ ] Tests have been added for new behaviour
- [ ] The changelog has been updated for any user-facing changes
