### PR TITLE
fix: replace undeclared variable for UnsupportedProceduralOperator message

### DIFF
--- a/compiler-core/src/parse/error.rs
+++ b/compiler-core/src/parse/error.rs
@@ -966,7 +966,7 @@ new variable with the same name as the previous one:
     let blobby = wibble
     let wibble = wibble + 20
     assert wibble == 30
-    assert bounce == 10
+    assert blobby == 10
 "
                     .into(),
                 ],

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__invalid_assignment_shorthand_divide_equals.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__invalid_assignment_shorthand_divide_equals.snap
@@ -21,4 +21,4 @@ new variable with the same name as the previous one:
     let blobby = wibble
     let wibble = wibble + 20
     assert wibble == 30
-    assert bounce == 10
+    assert blobby == 10

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__invalid_assignment_shorthand_minus_equals.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__invalid_assignment_shorthand_minus_equals.snap
@@ -21,4 +21,4 @@ new variable with the same name as the previous one:
     let blobby = wibble
     let wibble = wibble + 20
     assert wibble == 30
-    assert bounce == 10
+    assert blobby == 10

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__invalid_assignment_shorthand_modulo_equals.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__invalid_assignment_shorthand_modulo_equals.snap
@@ -21,4 +21,4 @@ new variable with the same name as the previous one:
     let blobby = wibble
     let wibble = wibble + 20
     assert wibble == 30
-    assert bounce == 10
+    assert blobby == 10

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__invalid_assignment_shorthand_plus_equals.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__invalid_assignment_shorthand_plus_equals.snap
@@ -21,4 +21,4 @@ new variable with the same name as the previous one:
     let blobby = wibble
     let wibble = wibble + 20
     assert wibble == 30
-    assert bounce == 10
+    assert blobby == 10

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__invalid_assignment_shorthand_plus_plus.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__invalid_assignment_shorthand_plus_plus.snap
@@ -21,4 +21,4 @@ new variable with the same name as the previous one:
     let blobby = wibble
     let wibble = wibble + 20
     assert wibble == 30
-    assert bounce == 10
+    assert blobby == 10

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__invalid_assignment_shorthand_times_equals.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__invalid_assignment_shorthand_times_equals.snap
@@ -21,4 +21,4 @@ new variable with the same name as the previous one:
     let blobby = wibble
     let wibble = wibble + 20
     assert wibble == 30
-    assert bounce == 10
+    assert blobby == 10


### PR DESCRIPTION
- [x] The changes in this PR have been discussed beforehand in an issue 
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes

Seems like the example variable is wrong (the variable `bounce` isn't declared before, it would give an out of scope error), I guess it went under the radar since both words start with letter '**b**'.

Related to **PR** #5987 