### PR TITLE
Skip binding in JavaScript when a switch value is used once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@
   expression now points to the entire function call.
   ([mmustafasenoglu](https://github.com/mmustafasenoglu))
 
+- Pattern matching on the JavaScript target now generates flatter code, with
+  nested `if` statements collapsed into a single condition and fewer
+  intermediate variables. This makes little difference to the size of a bundled
+  application, but the resulting code has fewer branches for JavaScript engines
+  to optimise.
+  ([John Downey](https://github.com/jtdowney))
+
 ### Build tool
 
 - The build tool now stores its build cache in a more compact binary format,

--- a/compiler-core/src/javascript/decision.rs
+++ b/compiler-core/src/javascript/decision.rs
@@ -23,7 +23,10 @@ use ecow::{EcoString, eco_format};
 use itertools::Itertools;
 use num_bigint::BigInt;
 use pretty_arena::*;
-use std::{collections::HashMap, sync::OnceLock};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::OnceLock,
+};
 
 pub const ASSIGNMENT_VAR: &str = "$";
 
@@ -390,6 +393,125 @@ impl<'a, 'doc> CasePrinter<'_, '_, 'a, '_, 'doc> {
         }
     }
 
+    /// Returns whether the value of `var` is going to be used more than once by
+    /// the switch made up of `choices` and `fallback`.
+    ///
+    /// A variable that is not bound to a name has its value inlined at every
+    /// reference, and any variable derived from it (for example `x.tail` or
+    /// `x[0]`) embeds that whole expression. So a single reference costs
+    /// nothing, while any further one recomputes the work a binding would have
+    /// done just once.
+    ///
+    fn value_used_more_than_once(
+        &self,
+        var: &Variable,
+        choices: &'a [(RuntimeCheck, Decision)],
+        fallback: &'a Decision,
+        fallback_check: &'a FallbackCheck,
+    ) -> bool {
+        // Every choice uses the value to perform its own check, so more than
+        // one choice already means more than one use.
+        if choices.len() > 1 {
+            return true;
+        }
+
+        // Otherwise there's exactly one choice (`switch` returns early when
+        // there's none) and its check is the first use, so the value gets used
+        // again as soon as any of the branches does.
+        let derived = derived_variables(var, choices, fallback_check);
+        choices
+            .iter()
+            .map(|(_check, decision)| decision)
+            .chain([fallback])
+            .any(|decision| self.decision_uses_value(decision, &derived))
+    }
+
+    /// Whether `decision` uses the value of one of the `derived` variables.
+    ///
+    fn decision_uses_value(&self, decision: &'a Decision, derived: &HashSet<usize>) -> bool {
+        match decision {
+            Decision::Fail => false,
+
+            // A clause that just returns one of the case subjects reuses it
+            // directly and its bindings are never used, so they can't make us
+            // recompute anything.
+            Decision::Run { body } if self.body_returns_subject(body) => false,
+            // Otherwise, we need to check if the body uses any of the derived
+            // variables.
+            Decision::Run { body } => self.body_uses_value(body, derived),
+
+            // A guarded body is different: even when it returns a subject, the
+            // bindings its check needs are used before the check itself, so
+            // those still count.
+            Decision::Guard {
+                if_true, if_false, ..
+            } => {
+                self.body_uses_value(if_true, derived)
+                    || self.decision_uses_value(if_false, derived)
+            }
+
+            // A nested switch checks the value it switches on, so if that is
+            // one of the derived variables then the value is used here no
+            // matter what the branches go on to do. Otherwise it's only used if
+            // one of those branches uses it.
+            Decision::Switch {
+                var,
+                choices,
+                fallback,
+                ..
+            } => {
+                derived.contains(&var.id)
+                    || choices
+                        .iter()
+                        .map(|(_check, decision)| decision)
+                        .chain([fallback.as_ref()])
+                        .any(|decision| self.decision_uses_value(decision, derived))
+            }
+        }
+    }
+
+    /// Whether the clause `body` belongs to just rebuilds and returns one of
+    /// the case subjects, like `Ok(value) -> Ok(value)` or `n -> n`.
+    ///
+    /// Such a clause is compiled to a `return` of the subject itself, so the
+    /// bindings in `body` are never emitted and the values they reference are
+    /// never used. Here `value` never makes it into the generated code, even
+    /// though the pattern binds it.
+    ///
+    fn body_returns_subject(&self, body: &'a Body) -> bool {
+        let DecisionKind::Case { clauses } = &self.kind else {
+            return false;
+        };
+
+        clauses
+            .get(body.clause_index)
+            .expect("invalid clause index")
+            .returned_subject()
+            .is_some()
+    }
+
+    /// Whether any value bound by `body` is one of the `derived` variables,
+    /// that is the variable we're deciding whether to bind and everything the
+    /// switch's checks pull out of it.
+    ///
+    /// Since those variables are not bound to a name, each binding that
+    /// references one repeats the whole expression its value is computed from,
+    /// which is exactly the work a binding would let us do just once.
+    ///
+    fn body_uses_value(&self, body: &'a Body, derived: &HashSet<usize>) -> bool {
+        body.bindings
+            .iter()
+            .filter_map(|(_name, value)| match value {
+                BoundValue::Variable(variable) => Some(variable),
+                BoundValue::BitArraySlice { bit_array, .. } => Some(bit_array),
+                BoundValue::StringSlice { subject, .. } => Some(subject),
+                BoundValue::LiteralString(_)
+                | BoundValue::LiteralInt(_)
+                | BoundValue::LiteralFloat(_) => None,
+            })
+            .any(|variable| derived.contains(&variable.id))
+    }
+
     fn body_expression(
         &mut self,
         arena: &'doc DocumentArena<'a, 'doc>,
@@ -492,11 +614,17 @@ impl<'a, 'doc> CasePrinter<'_, '_, 'a, '_, 'doc> {
         // Otherwise we'll have to generate a series of if-else to check which
         // pattern is going to match!
         let mut assignments = vec![];
-        if !self.variables.is_bound_in_scope(var) {
+        if !self.variables.is_bound_in_scope(var)
+            && self.value_used_more_than_once(var, choices, fallback, fallback_check)
+        {
             // If the variable we need to perform a check on is not already bound
             // in scope we will be binding it to a new made up name. This way we
             // can also reference this exact name in further checks instead of
             // recomputing the value each time.
+            //
+            // If the value is only ever used once there's nothing to share the
+            // name with, so binding it would just add a statement and stop the
+            // resulting `if` from being merged into the enclosing one.
             let name = self.variables.next_local_var(&ASSIGNMENT_VAR.into());
             let value = self.variables.get_value(var);
             self.variables.bind(name.clone(), var);
@@ -690,10 +818,19 @@ impl<'a, 'doc> CasePrinter<'_, '_, 'a, '_, 'doc> {
             body: if_body,
         } = if_
         {
+            // When the `if` body is empty the check gets negated and the else
+            // body becomes the entire statement, so it needs a block of its own
+            // rather than being joined onto an `else` keyword.
+            let else_body = if if_body.is_empty() {
+                break_block(arena, else_body.into_doc(arena))
+            } else {
+                else_body.document_after_else(arena)
+            };
+
             CaseBody::IfElse {
                 check,
                 if_body,
-                else_body: else_body.document_after_else(arena),
+                else_body,
                 fallback_decision: fallback,
             }
         } else {
@@ -894,6 +1031,43 @@ fn multiple_single_character_prefix_checks(choices: &[(RuntimeCheck, Decision)])
     }
 
     false
+}
+
+/// The ids of `var` and of every variable the switch's checks pull out of it.
+///
+/// Using one of these uses `var`'s value as well, for example, the value of
+/// `x.tail` is the value of `x` with `.tail` tacked onto it.
+///
+fn derived_variables(
+    var: &Variable,
+    choices: &[(RuntimeCheck, Decision)],
+    fallback_check: &FallbackCheck,
+) -> HashSet<usize> {
+    let checks = choices
+        .iter()
+        .map(|(check, _decision)| check)
+        .chain(match fallback_check {
+            FallbackCheck::RuntimeCheck { check } => Some(check),
+            FallbackCheck::InfiniteCatchAll | FallbackCheck::CatchAll { .. } => None,
+        });
+
+    checks.fold(HashSet::from_iter([var.id]), |mut derived, check| {
+        let introduced: &[&Variable] = &match check {
+            RuntimeCheck::Int { .. }
+            | RuntimeCheck::Float { .. }
+            | RuntimeCheck::String { .. }
+            | RuntimeCheck::BitArray { .. }
+            | RuntimeCheck::EmptyList => vec![],
+
+            RuntimeCheck::StringPrefix { rest, .. } => vec![rest],
+            RuntimeCheck::Tuple { elements, .. } => elements.iter().collect(),
+            RuntimeCheck::Variant { fields, .. } => fields.iter().collect(),
+            RuntimeCheck::NonEmptyList { first, rest } => vec![first, rest],
+        };
+
+        derived.extend(introduced.iter().map(|variable| variable.id));
+        derived
+    })
 }
 
 pub fn let_<'a, 'doc>(

--- a/compiler-core/src/javascript/tests/case.rs
+++ b/compiler-core/src/javascript/tests/case.rs
@@ -1127,3 +1127,51 @@ pub fn go(bit_array) {
 "
     );
 }
+
+#[test]
+fn single_choice_switch_does_not_bind_subject() {
+    assert_js!(
+        "
+pub type Wibble {
+  Wibble(Int, Int)
+  Wobble
+}
+
+pub fn go(x) {
+  case x {
+    Wibble(1, 2) -> 1
+    _ -> 2
+  }
+}
+"
+    );
+}
+
+#[test]
+fn single_choice_switch_binds_subject_referenced_more_than_once() {
+    assert_js!(
+        "
+pub fn go(sequences) {
+  case sequences {
+    [] -> 0
+    [_] -> 1
+    [a, b, ..rest] -> a + b + go(rest)
+  }
+}
+"
+    );
+}
+
+#[test]
+fn single_choice_switch_binds_subject_referenced_by_guard() {
+    assert_js!(
+        "
+pub fn go(x) {
+  case x {
+    [a, b, ..rest] if b > 0 -> [a, b, ..rest]
+    _ -> []
+  }
+}
+"
+    );
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__assert1.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__assert1.snap
@@ -11,21 +11,7 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  let $ = x[0];
-  if ($ === 1) {
-    let $1 = x[1];
-    if (!($1 === 2)) {
-      throw makeError(
-        "let_assert",
-        FILEPATH,
-        "my/mod",
-        1,
-        "go",
-        "Pattern match failed, no pattern matched the value.",
-        { value: x, start: 15, end: 37, pattern_start: 26, pattern_end: 33 }
-      )
-    }
-  } else {
+  if (!(x[0] === 1 && x[1] === 2)) {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__nested_binding.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__nested_binding.snap
@@ -19,25 +19,11 @@ export function go(x) {
   let t;
   let b;
   let c;
-  let $ = x[3];
-  if ($ === 1) {
-    let $1 = x[1][2];
-    if ($1 === 2) {
-      a = x[0];
-      t = x[1];
-      b = x[1][0];
-      c = x[1][1];
-    } else {
-      throw makeError(
-        "let_assert",
-        FILEPATH,
-        "my/mod",
-        3,
-        "go",
-        "Pattern match failed, no pattern matched the value.",
-        { value: x, start: 18, end: 60, pattern_start: 29, pattern_end: 56 }
-      )
-    }
+  if (x[3] === 1 && x[1][2] === 2) {
+    a = x[0];
+    t = x[1];
+    b = x[1][0];
+    c = x[1][1];
   } else {
     throw makeError(
       "let_assert",

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__tuple_matching.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__tuple_matching.snap
@@ -15,21 +15,7 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  let $ = x[0];
-  if ($ === 1) {
-    let $1 = x[1];
-    if (!($1 === 2)) {
-      throw makeError(
-        "let_assert",
-        FILEPATH,
-        "my/mod",
-        3,
-        "go",
-        "Pattern match failed, no pattern matched the value.",
-        { value: x, start: 18, end: 40, pattern_start: 29, pattern_end: 36 }
-      )
-    }
-  } else {
+  if (!(x[0] === 1 && x[1] === 2)) {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__variable_renaming.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__assignments__variable_renaming.snap
@@ -35,8 +35,7 @@ export function go(x, wibble) {
   let a$1 = 2;
   wibble(a$1);
   let a$2;
-  let $ = x[1];
-  if ($ === 3) {
+  if (x[1] === 3) {
     a$2 = x[0];
   } else {
     throw makeError(

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__tuple_bit_array.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__tuple_bit_array.snap
@@ -15,8 +15,7 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  let $ = x[0];
-  if (!($.bitSize === 0)) {
+  if (!(x[0].bitSize === 0)) {
     throw makeError(
       "let_assert",
       FILEPATH,

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__tuple_bit_array_case.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__tuple_bit_array_case.snap
@@ -14,8 +14,7 @@ pub fn go(x) {
 
 ----- COMPILED JAVASCRIPT
 export function go(x) {
-  let $ = x[0];
-  if ($.bitSize === 0) {
+  if (x[0].bitSize === 0) {
     return 1;
   } else {
     return 2;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__tuple_multiple_bit_arrays.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__tuple_multiple_bit_arrays.snap
@@ -15,17 +15,16 @@ import { makeError } from "../gleam.mjs";
 const FILEPATH = "src/module.gleam";
 
 export function go(x) {
-  let $ = x[0];
-  if ($.bitSize === 0) {
-    let $1 = x[1];
-    if ($1.bitSize === 8) {
-      let $2 = x[2];
+  if (x[0].bitSize === 0) {
+    let $ = x[1];
+    if ($.bitSize === 8) {
+      let $1 = x[2];
       if (!(
-        $2.bitSize >= 8 &&
-        $1.byteAt(0) === 1 &&
-        $2.byteAt(0) === 2 &&
-        $2.bitSize === 16 &&
-        $2.byteAt(1) === 3
+        $1.bitSize >= 8 &&
+        $.byteAt(0) === 1 &&
+        $1.byteAt(0) === 2 &&
+        $1.bitSize === 16 &&
+        $1.byteAt(1) === 3
       )) {
         throw makeError(
           "let_assert",

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__tuple_multiple_bit_arrays_case.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__bit_arrays__tuple_multiple_bit_arrays_case.snap
@@ -14,17 +14,16 @@ pub fn go(x) {
 
 ----- COMPILED JAVASCRIPT
 export function go(x) {
-  let $ = x[0];
-  if ($.bitSize === 0) {
-    let $1 = x[1];
-    if ($1.bitSize === 8) {
-      let $2 = x[2];
+  if (x[0].bitSize === 0) {
+    let $ = x[1];
+    if ($.bitSize === 8) {
+      let $1 = x[2];
       if (
-        $2.bitSize >= 8 &&
-        $1.byteAt(0) === 1 &&
-        $2.byteAt(0) === 2 &&
-        $2.bitSize === 16 &&
-        $2.byteAt(1) === 3
+        $1.bitSize >= 8 &&
+        $.byteAt(0) === 1 &&
+        $1.byteAt(0) === 2 &&
+        $1.bitSize === 16 &&
+        $1.byteAt(1) === 3
       ) {
         return true;
       } else {

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__case_branches_guards_are_wrapped_in_parentheses.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__case_branches_guards_are_wrapped_in_parentheses.snap
@@ -19,8 +19,7 @@ export function anything() {
   while (true) {
     let $ = $List$Empty$const;
     if (!($ instanceof $Empty)) {
-      let $1 = $.tail;
-      if ($1 instanceof $Empty && (false || true)) {
+      if ($.tail instanceof $Empty && (false || true)) {
         let a = $.head;
         return a;
       }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__case_building_list_matched_by_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__case_building_list_matched_by_pattern.snap
@@ -21,24 +21,17 @@ export function go(x) {
   } else {
     let $ = x.tail;
     if ($ instanceof $Empty) {
-      let $1 = x.head;
-      if ($1 === 1) {
+      if (x.head === 1) {
         return x;
       } else {
         return x;
       }
+    } else if ($.tail instanceof $Empty) {
+      return x;
+    } else if (x.head === 1) {
+      return x;
     } else {
-      let $1 = $.tail;
-      if ($1 instanceof $Empty) {
-        return x;
-      } else {
-        let $2 = x.head;
-        if ($2 === 1) {
-          return x;
-        } else {
-          return x;
-        }
-      }
+      return x;
     }
   }
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__case_building_matched_value_alias_2.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__case_building_matched_value_alias_2.snap
@@ -20,8 +20,7 @@ import { Ok } from "../gleam.mjs";
 
 export function go(x) {
   if (x instanceof Ok) {
-    let $ = x[0];
-    if ($ === 1) {
+    if (x[0] === 1) {
       return x;
     } else {
       return new Ok(2);

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__case_building_matched_value_alias_3.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__case_building_matched_value_alias_3.snap
@@ -20,8 +20,7 @@ import { Ok } from "../gleam.mjs";
 
 export function go(x) {
   if (x instanceof Ok) {
-    let $ = x[0];
-    if ($ === 1) {
+    if (x[0] === 1) {
       return x;
     } else {
       return new Ok(2);

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__case_building_record_matched_by_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__case_building_record_matched_by_pattern.snap
@@ -16,8 +16,7 @@ import { Ok, Error } from "../gleam.mjs";
 
 export function go(x) {
   if (x instanceof Ok) {
-    let $ = x[0];
-    if ($ === 1) {
+    if (x[0] === 1) {
       return x;
     } else {
       return x;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__case_building_record_with_labels_matched_by_pattern_1.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__case_building_record_with_labels_matched_by_pattern_1.snap
@@ -44,13 +44,8 @@ export const Wibble$isWobble = (value) => value instanceof Wobble;
 export const Wibble$Wobble$0 = (value) => value[0];
 
 export function go(x) {
-  if (x instanceof Wibble) {
-    let $ = x.int;
-    if ($ === 1) {
-      return x;
-    } else {
-      return new Wobble(1);
-    }
+  if (x instanceof Wibble && x.int === 1) {
+    return x;
   } else {
     return new Wobble(1);
   }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__case_building_record_with_labels_matched_by_pattern_5.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__case_building_record_with_labels_matched_by_pattern_5.snap
@@ -44,13 +44,8 @@ export const Wibble$isWobble = (value) => value instanceof Wobble;
 export const Wibble$Wobble$0 = (value) => value[0];
 
 export function go(x) {
-  if (x instanceof Wibble) {
-    let $ = x.int;
-    if ($ === 1) {
-      return x;
-    } else {
-      return new Wobble(1);
-    }
+  if (x instanceof Wibble && x.int === 1) {
+    return x;
   } else {
     return new Wobble(1);
   }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__case_building_record_with_labels_matched_by_pattern_6.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__case_building_record_with_labels_matched_by_pattern_6.snap
@@ -44,13 +44,8 @@ export const Wibble$isWobble = (value) => value instanceof Wobble;
 export const Wibble$Wobble$0 = (value) => value[0];
 
 export function go(x) {
-  if (x instanceof Wibble) {
-    let $ = x.int;
-    if ($ === 1) {
-      return x;
-    } else {
-      return new Wobble(1);
-    }
+  if (x instanceof Wibble && x.int === 1) {
+    return x;
   } else {
     return new Wobble(1);
   }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__case_building_record_with_select_matched_by_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__case_building_record_with_select_matched_by_pattern.snap
@@ -18,13 +18,8 @@ import * as $gleam from "../gleam.mjs";
 import { Ok, Error } from "../gleam.mjs";
 
 export function go(x) {
-  if (x instanceof Ok) {
-    let $ = x[0];
-    if ($ === 1) {
-      return x;
-    } else {
-      return new Error(undefined);
-    }
+  if (x instanceof Ok && x[0] === 1) {
+    return x;
   } else {
     return new Error(undefined);
   }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__case_building_record_with_select_matched_by_pattern_2.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__case_building_record_with_select_matched_by_pattern_2.snap
@@ -18,13 +18,8 @@ import * as $gleam from "../gleam.mjs";
 import { Error } from "../gleam.mjs";
 
 export function go(x) {
-  if (x instanceof $gleam.Ok) {
-    let $ = x[0];
-    if ($ === 1) {
-      return x;
-    } else {
-      return new Error(undefined);
-    }
+  if (x instanceof $gleam.Ok && x[0] === 1) {
+    return x;
   } else {
     return new Error(undefined);
   }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__case_building_record_with_select_matched_by_pattern_3.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__case_building_record_with_select_matched_by_pattern_3.snap
@@ -18,13 +18,8 @@ import * as $gleam from "../gleam.mjs";
 import { Error } from "../gleam.mjs";
 
 export function go(x) {
-  if (x instanceof $gleam.Ok) {
-    let $ = x[0];
-    if ($ === 1) {
-      return x;
-    } else {
-      return new Error(undefined);
-    }
+  if (x instanceof $gleam.Ok && x[0] === 1) {
+    return x;
   } else {
     return new Error(undefined);
   }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__case_with_multiple_subjects_building_list_matched_by_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__case_with_multiple_subjects_building_list_matched_by_pattern.snap
@@ -25,30 +25,17 @@ export function go(n, x) {
   } else {
     let $ = x.tail;
     if ($ instanceof $Empty) {
-      if (n === 3) {
-        let $1 = x.head;
-        if ($1 === 1) {
-          return x;
-        } else {
-          return x;
-        }
+      if (n === 3 && x.head === 1) {
+        return x;
       } else {
         return x;
       }
+    } else if ($.tail instanceof $Empty) {
+      return x;
+    } else if (n === 3 && x.head === 1) {
+      return x;
     } else {
-      let $1 = $.tail;
-      if ($1 instanceof $Empty) {
-        return x;
-      } else if (n === 3) {
-        let $2 = x.head;
-        if ($2 === 1) {
-          return x;
-        } else {
-          return x;
-        }
-      } else {
-        return x;
-      }
+      return x;
     }
   }
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__case_with_multiple_subjects_building_record_matched_by_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__case_with_multiple_subjects_building_record_matched_by_pattern.snap
@@ -16,13 +16,8 @@ import { Ok, Error } from "../gleam.mjs";
 
 export function go(x, y) {
   if (x instanceof Ok) {
-    if (y instanceof Error) {
-      let $ = x[0];
-      if ($ === 1) {
-        return x;
-      } else {
-        return new Error(undefined);
-      }
+    if (y instanceof Error && x[0] === 1) {
+      return x;
     } else {
       return new Error(undefined);
     }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__case_with_multiple_subjects_building_same_value_as_two_subjects_one_is_picked.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__case_with_multiple_subjects_building_same_value_as_two_subjects_one_is_picked.snap
@@ -20,18 +20,8 @@ import { Ok, Error } from "../gleam.mjs";
 
 export function go(x, y) {
   if (y instanceof Ok) {
-    if (x instanceof $gleam.Ok) {
-      let $ = y[0];
-      if ($ === 1) {
-        let $1 = x[0];
-        if ($1 === 1) {
-          return x;
-        } else {
-          return new Error(undefined);
-        }
-      } else {
-        return new Error(undefined);
-      }
+    if (x instanceof $gleam.Ok && y[0] === 1 && x[0] === 1) {
+      return x;
     } else {
       return new Error(undefined);
     }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__guard_variable_only_brought_into_scope_when_needed.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__guard_variable_only_brought_into_scope_when_needed.snap
@@ -24,19 +24,16 @@ export function go(x) {
     let $ = x.tail;
     if ($ instanceof $Empty) {
       return 2;
-    } else {
-      let $1 = $.tail;
-      if ($1 instanceof $Empty) {
-        let a = x.head;
-        if (a === 1) {
-          let b = $.head;
-          return a + b;
-        } else {
-          return 2;
-        }
+    } else if ($.tail instanceof $Empty) {
+      let a = x.head;
+      if (a === 1) {
+        let b = $.head;
+        return a + b;
       } else {
         return 2;
       }
+    } else {
+      return 2;
     }
   }
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__list_with_tail_used_in_guard.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__list_with_tail_used_in_guard.snap
@@ -17,17 +17,14 @@ import { toList, Empty as $Empty, prepend as listPrepend, isEqual } from "../gle
 export function go(x, y) {
   if (x instanceof $Empty) {
     return false;
-  } else {
-    let $ = x.head;
-    if ($ === 1) {
-      let x$1 = x.tail;
-      if (isEqual(listPrepend(1, listPrepend(2, x$1)), y)) {
-        return true;
-      } else {
-        return false;
-      }
+  } else if (x.head === 1) {
+    let x$1 = x.tail;
+    if (isEqual(listPrepend(1, listPrepend(2, x$1)), y)) {
+      return true;
     } else {
       return false;
     }
+  } else {
+    return false;
   }
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__nested_string_prefix_match.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__nested_string_prefix_match.snap
@@ -28,28 +28,15 @@ export function main() {
       let $3 = $2.tail;
       if ($3 instanceof $Empty) {
         return 1;
+      } else if (
+        $3.tail instanceof $Empty &&
+        $1.head === "a" &&
+        $2.head.startsWith("b ") &&
+        $3.head === "d"
+      ) {
+        return 1;
       } else {
-        let $4 = $3.tail;
-        if ($4 instanceof $Empty) {
-          let $5 = $1.head;
-          if ($5 === "a") {
-            let $6 = $2.head;
-            if ($6.startsWith("b ")) {
-              let $7 = $3.head;
-              if ($7 === "d") {
-                return 1;
-              } else {
-                return 1;
-              }
-            } else {
-              return 1;
-            }
-          } else {
-            return 1;
-          }
-        } else {
-          return 1;
-        }
+        return 1;
       }
     }
   }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__nested_string_prefix_match_that_would_crash_on_js.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__nested_string_prefix_match_that_would_crash_on_js.snap
@@ -24,23 +24,14 @@ export function main() {
     let $2 = $1.tail;
     if ($2 instanceof $Empty) {
       return 1;
+    } else if (
+      $2.tail instanceof $Empty &&
+      $1.head.startsWith("b ") &&
+      $2.head === "d"
+    ) {
+      return 1;
     } else {
-      let $3 = $2.tail;
-      if ($3 instanceof $Empty) {
-        let $4 = $1.head;
-        if ($4.startsWith("b ")) {
-          let $5 = $2.head;
-          if ($5 === "d") {
-            return 1;
-          } else {
-            return 1;
-          }
-        } else {
-          return 1;
-        }
-      } else {
-        return 1;
-      }
+      return 1;
     }
   }
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__no_duplicate_let_after_directly_matching_case.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__no_duplicate_let_after_directly_matching_case.snap
@@ -20,8 +20,7 @@ pub fn go() {
 export function go() {
   let _block;
   let $ = [1, 2];
-  let $1 = $[0];
-  if ($1 === 1) {
+  if ($[0] === 1) {
     let b = $[1];
     _block = b;
   } else {
@@ -29,7 +28,7 @@ export function go() {
     _block = b;
   }
   let x = _block;
-  let $2 = [x, 3];
-  let a = $2[0];
+  let $1 = [x, 3];
+  let a = $1[0];
   return a;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__record_update_in_pipeline_in_case_clause.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__record_update_in_pipeline_in_case_clause.snap
@@ -45,25 +45,21 @@ function identity(x) {
 }
 
 export function go(x) {
-  let $ = x.wibble;
-  if ($ === 1) {
+  if (x.wibble === 1) {
     let _pipe = new Wibble(4, x.wobble);
     return identity(_pipe);
+  } else if (x.wobble === 3) {
+    let _pipe = new Wibble(x.wibble, 10);
+    return identity(_pipe);
   } else {
-    let $1 = x.wobble;
-    if ($1 === 3) {
-      let _pipe = new Wibble(x.wibble, 10);
-      return identity(_pipe);
-    } else {
-      throw makeError(
-        "panic",
-        FILEPATH,
-        "my/mod",
-        14,
-        "go",
-        "`panic` expression evaluated.",
-        {}
-      )
-    }
+    throw makeError(
+      "panic",
+      FILEPATH,
+      "my/mod",
+      14,
+      "go",
+      "`panic` expression evaluated.",
+      {}
+    )
   }
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__semicolon_exists_with_case.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__semicolon_exists_with_case.snap
@@ -20,14 +20,8 @@ export function go() {
   if ($1 === 2) {
     let b = $[1];
     b;
-  } else if ($1 === 1) {
-    let $2 = $[1];
-    if ($2 === 3) {
-      2;
-    } else {
-      let a = $1;
-      a;
-    }
+  } else if ($1 === 1 && $[1] === 3) {
+    2;
   } else {
     let a = $1;
     a;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__single_choice_switch_binds_subject_referenced_by_guard.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__single_choice_switch_binds_subject_referenced_by_guard.snap
@@ -1,0 +1,34 @@
+---
+source: compiler-core/src/javascript/tests/case.rs
+expression: "\npub fn go(x) {\n  case x {\n    [a, b, ..rest] if b > 0 -> [a, b, ..rest]\n    _ -> []\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn go(x) {
+  case x {
+    [a, b, ..rest] if b > 0 -> [a, b, ..rest]
+    _ -> []
+  }
+}
+
+
+----- COMPILED JAVASCRIPT
+import { Empty as $Empty, List$Empty$const as $List$Empty$const } from "../gleam.mjs";
+
+export function go(x) {
+  if (x instanceof $Empty) {
+    return $List$Empty$const;
+  } else {
+    let $ = x.tail;
+    if ($ instanceof $Empty) {
+      return $List$Empty$const;
+    } else {
+      let b = $.head;
+      if (b > 0) {
+        return x;
+      } else {
+        return $List$Empty$const;
+      }
+    }
+  }
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__single_choice_switch_binds_subject_referenced_more_than_once.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__single_choice_switch_binds_subject_referenced_more_than_once.snap
@@ -1,0 +1,33 @@
+---
+source: compiler-core/src/javascript/tests/case.rs
+expression: "\npub fn go(sequences) {\n  case sequences {\n    [] -> 0\n    [_] -> 1\n    [a, b, ..rest] -> a + b + go(rest)\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn go(sequences) {
+  case sequences {
+    [] -> 0
+    [_] -> 1
+    [a, b, ..rest] -> a + b + go(rest)
+  }
+}
+
+
+----- COMPILED JAVASCRIPT
+import { Empty as $Empty } from "../gleam.mjs";
+
+export function go(sequences) {
+  if (sequences instanceof $Empty) {
+    return 0;
+  } else {
+    let $ = sequences.tail;
+    if ($ instanceof $Empty) {
+      return 1;
+    } else {
+      let a = sequences.head;
+      let b = $.head;
+      let rest = $.tail;
+      return (a + b) + go(rest);
+    }
+  }
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__single_choice_switch_does_not_bind_subject.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__single_choice_switch_does_not_bind_subject.snap
@@ -1,0 +1,46 @@
+---
+source: compiler-core/src/javascript/tests/case.rs
+expression: "\npub type Wibble {\n  Wibble(Int, Int)\n  Wobble\n}\n\npub fn go(x) {\n  case x {\n    Wibble(1, 2) -> 1\n    _ -> 2\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub type Wibble {
+  Wibble(Int, Int)
+  Wobble
+}
+
+pub fn go(x) {
+  case x {
+    Wibble(1, 2) -> 1
+    _ -> 2
+  }
+}
+
+
+----- COMPILED JAVASCRIPT
+import { CustomType as $CustomType } from "../gleam.mjs";
+
+export class Wibble extends $CustomType {
+  constructor($0, $1) {
+    super();
+    this[0] = $0;
+    this[1] = $1;
+  }
+}
+export const Wibble$Wibble = ($0, $1) => new Wibble($0, $1);
+export const Wibble$isWibble = (value) => value instanceof Wibble;
+export const Wibble$Wibble$0 = (value) => value[0];
+export const Wibble$Wibble$1 = (value) => value[1];
+
+export class Wobble extends $CustomType {}
+export const Wibble$Wobble$const = new Wobble();
+export const Wibble$Wobble = () => Wibble$Wobble$const;
+export const Wibble$isWobble = (value) => value instanceof Wobble;
+
+export function go(x) {
+  if (x instanceof Wibble && x[0] === 1 && x[1] === 2) {
+    return 1;
+  } else {
+    return 2;
+  }
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__tuple_and_guard.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__tuple_and_guard.snap
@@ -15,8 +15,7 @@ pub fn go(x) {
 ----- COMPILED JAVASCRIPT
 export function go(x) {
   let $ = [1, 2];
-  let $1 = $[0];
-  if ($1 === 1) {
+  if ($[0] === 1) {
     let a = $[1];
     if (a === 2) {
       return 1;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__alternative_patterns_assignment.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__alternative_patterns_assignment.snap
@@ -22,14 +22,11 @@ export function main(xs) {
     if ($ instanceof $Empty) {
       let x = xs.head;
       return x;
+    } else if ($.tail instanceof $Empty) {
+      let x = $.head;
+      return x;
     } else {
-      let $1 = $.tail;
-      if ($1 instanceof $Empty) {
-        let x = $.head;
-        return x;
-      } else {
-        return 1;
-      }
+      return 1;
     }
   }
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__alternative_patterns_guard.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__alternative_patterns_guard.snap
@@ -26,18 +26,15 @@ export function main(xs) {
       } else {
         return 0;
       }
-    } else {
-      let $1 = $.tail;
-      if ($1 instanceof $Empty) {
-        let x = $.head;
-        if (x === 1) {
-          return x;
-        } else {
-          return 0;
-        }
+    } else if ($.tail instanceof $Empty) {
+      let x = $.head;
+      if (x === 1) {
+        return x;
       } else {
         return 0;
       }
+    } else {
+      return 0;
     }
   }
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__alternative_patterns_list.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__alternative_patterns_list.snap
@@ -20,29 +20,15 @@ export function main(xs) {
   } else {
     let $ = xs.tail;
     if ($ instanceof $Empty) {
-      let $1 = xs.head;
-      if ($1 === 1) {
+      if (xs.head === 1) {
         return 0;
       } else {
         return 1;
       }
+    } else if ($.tail instanceof $Empty && xs.head === 1 && $.head === 2) {
+      return 0;
     } else {
-      let $1 = $.tail;
-      if ($1 instanceof $Empty) {
-        let $2 = xs.head;
-        if ($2 === 1) {
-          let $3 = $.head;
-          if ($3 === 2) {
-            return 0;
-          } else {
-            return 1;
-          }
-        } else {
-          return 1;
-        }
-      } else {
-        return 1;
-      }
+      return 1;
     }
   }
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__destructure_custom_type_with_named_fields.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__destructure_custom_type_with_named_fields.snap
@@ -41,8 +41,7 @@ export function go(cat) {
   let y = cat.cuteness;
   let x$1 = cat.name;
   let x$2;
-  let $ = cat.cuteness;
-  if ($ === 4) {
+  if (cat.cuteness === 4) {
     x$2 = cat.name;
   } else {
     throw makeError(

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__imported_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__imported_pattern.snap
@@ -23,16 +23,12 @@ import * as $other from "../other.mjs";
 import { Two } from "../other.mjs";
 
 export function main(x) {
-  let $ = x.a;
-  if ($ === 1) {
+  if (x.a === 1) {
     return 1;
+  } else if (x.b === 2) {
+    let c = x.c;
+    return c;
   } else {
-    let $1 = x.b;
-    if ($1 === 2) {
-      let c = x.c;
-      return c;
-    } else {
-      return 3;
-    }
+    return 3;
   }
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__case.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__case.snap
@@ -24,13 +24,10 @@ export function go(xs) {
     let $ = xs.tail;
     if ($ instanceof $Empty) {
       return 1;
+    } else if ($.tail instanceof $Empty) {
+      return 2;
     } else {
-      let $1 = $.tail;
-      if ($1 instanceof $Empty) {
-        return 2;
-      } else {
-        return 9999;
-      }
+      return 9999;
     }
   }
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__list_destructuring.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__list_destructuring.snap
@@ -41,21 +41,18 @@ export function go(x, y) {
       "Pattern match failed, no pattern matched the value.",
       { value: x, start: 41, end: 59, pattern_start: 52, pattern_end: 55 }
     )
+  } else if (x.tail instanceof $Empty) {
+    a = x.head;
   } else {
-    let $ = x.tail;
-    if ($ instanceof $Empty) {
-      a = x.head;
-    } else {
-      throw makeError(
-        "let_assert",
-        FILEPATH,
-        "my/mod",
-        4,
-        "go",
-        "Pattern match failed, no pattern matched the value.",
-        { value: x, start: 41, end: 59, pattern_start: 52, pattern_end: 55 }
-      )
-    }
+    throw makeError(
+      "let_assert",
+      FILEPATH,
+      "my/mod",
+      4,
+      "go",
+      "Pattern match failed, no pattern matched the value.",
+      { value: x, start: 41, end: 59, pattern_start: 52, pattern_end: 55 }
+    )
   }
   if (x instanceof $Empty) {
     throw makeError(
@@ -68,8 +65,8 @@ export function go(x, y) {
       { value: x, start: 62, end: 83, pattern_start: 73, pattern_end: 79 }
     )
   } else {
-    let $1 = x.tail;
-    if ($1 instanceof $Empty) {
+    let $ = x.tail;
+    if ($ instanceof $Empty) {
       throw makeError(
         "let_assert",
         FILEPATH,
@@ -79,51 +76,16 @@ export function go(x, y) {
         "Pattern match failed, no pattern matched the value.",
         { value: x, start: 62, end: 83, pattern_start: 73, pattern_end: 79 }
       )
-    } else {
-      let $2 = $1.tail;
-      if ($2 instanceof $Empty) {
-        let $3 = x.head;
-        if ($3 === 1) {
-          let $4 = $1.head;
-          if (!($4 === 2)) {
-            throw makeError(
-              "let_assert",
-              FILEPATH,
-              "my/mod",
-              5,
-              "go",
-              "Pattern match failed, no pattern matched the value.",
-              {
-                value: x,
-                start: 62,
-                end: 83,
-                pattern_start: 73,
-                pattern_end: 79
-              }
-            )
-          }
-        } else {
-          throw makeError(
-            "let_assert",
-            FILEPATH,
-            "my/mod",
-            5,
-            "go",
-            "Pattern match failed, no pattern matched the value.",
-            { value: x, start: 62, end: 83, pattern_start: 73, pattern_end: 79 }
-          )
-        }
-      } else {
-        throw makeError(
-          "let_assert",
-          FILEPATH,
-          "my/mod",
-          5,
-          "go",
-          "Pattern match failed, no pattern matched the value.",
-          { value: x, start: 62, end: 83, pattern_start: 73, pattern_end: 79 }
-        )
-      }
+    } else if (!($.tail instanceof $Empty && x.head === 1 && $.head === 2)) {
+      throw makeError(
+        "let_assert",
+        FILEPATH,
+        "my/mod",
+        5,
+        "go",
+        "Pattern match failed, no pattern matched the value.",
+        { value: x, start: 62, end: 83, pattern_start: 73, pattern_end: 79 }
+      )
     }
   }
   let b;
@@ -138,8 +100,8 @@ export function go(x, y) {
       { value: y, start: 86, end: 113, pattern_start: 97, pattern_end: 109 }
     )
   } else {
-    let $5 = y.tail;
-    if ($5 instanceof $Empty) {
+    let $1 = y.tail;
+    if ($1 instanceof $Empty) {
       throw makeError(
         "let_assert",
         FILEPATH,
@@ -149,40 +111,18 @@ export function go(x, y) {
         "Pattern match failed, no pattern matched the value.",
         { value: y, start: 86, end: 113, pattern_start: 97, pattern_end: 109 }
       )
+    } else if ($1.tail instanceof $Empty && $1.head[0] === 3) {
+      b = $1.head[1];
     } else {
-      let $6 = $5.tail;
-      if ($6 instanceof $Empty) {
-        let $7 = $5.head[0];
-        if ($7 === 3) {
-          b = $5.head[1];
-        } else {
-          throw makeError(
-            "let_assert",
-            FILEPATH,
-            "my/mod",
-            6,
-            "go",
-            "Pattern match failed, no pattern matched the value.",
-            {
-              value: y,
-              start: 86,
-              end: 113,
-              pattern_start: 97,
-              pattern_end: 109
-            }
-          )
-        }
-      } else {
-        throw makeError(
-          "let_assert",
-          FILEPATH,
-          "my/mod",
-          6,
-          "go",
-          "Pattern match failed, no pattern matched the value.",
-          { value: y, start: 86, end: 113, pattern_start: 97, pattern_end: 109 }
-        )
-      }
+      throw makeError(
+        "let_assert",
+        FILEPATH,
+        "my/mod",
+        6,
+        "go",
+        "Pattern match failed, no pattern matched the value.",
+        { value: y, start: 86, end: 113, pattern_start: 97, pattern_end: 109 }
+      )
     }
   }
   let head;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__sourcemaps__sourcemap_with_complex_case_expression.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__sourcemaps__sourcemap_with_complex_case_expression.snap
@@ -19,27 +19,17 @@ expression: "\npub fn go(one, other) {\n  case one, other {\n    Ok(1), Error(_)
 2 |
 3 |export function go(one, other) {
 4 |  if (one instanceof Ok) {
-5 |    if (other instanceof Error) {
-6 |      let $ = one[0];
-7 |      if ($ === 1) {
-8 |        return 1;
-9 |      } else {
-10 |        return 2;
-11 |      }
-12 |    } else {
-13 |      return 2;
-14 |    }
-15 |  } else if (other instanceof Ok) {
-16 |    let $ = other[0];
-17 |    if ($ === 2) {
-18 |      return 3;
-19 |    } else {
-20 |      return 4;
-21 |    }
-22 |  } else {
-23 |    return 4;
-24 |  }
-25 |}
+5 |    if (other instanceof Error && one[0] === 1) {
+6 |      return 1;
+7 |    } else {
+8 |      return 2;
+9 |    }
+10 |  } else if (other instanceof Ok && other[0] === 2) {
+11 |    return 3;
+12 |  } else {
+13 |    return 4;
+14 |  }
+15 |}
 
 ----- SOURCE MAP
 File: my/mod.mjs
@@ -68,46 +58,36 @@ one, other {
     Ok(1), Error(_) -> 
 ⏷
 if (one instanceof Ok) {
-    if (other instanceof Error) {
-      let $ = one[0];
-      if ($ === 1) {
-        
+    if (other instanceof Error && one[0] === 1) {
+      
 ----- 
 1
     Ok(_), _ -> 
 ⏷
 return 1;
-      } else {
-        
+    } else {
+      
 ----- 
 2
     Error(_), Ok(2) -> 
 ⏷
 return 2;
-      }
-    } else {
-      return 2;
     }
-  } else if (other instanceof Ok) {
-    let $ = other[0];
-    if ($ === 2) {
-      
+  } else if (other instanceof Ok && other[0] === 2) {
+    
 ----- 
 3
     _, _ -> 
 ⏷
 return 3;
-    } else {
-      
+  } else {
+    
 ----- 
 4
   }
 }
 ⏷
 return 4;
-    }
-  } else {
-    return 4;
   }
 }
 ----- 

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__strings__exact_string_after_longer_prefix.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__strings__exact_string_after_longer_prefix.snap
@@ -21,13 +21,10 @@ export function classify(input, a, b) {
   } else if (input.charCodeAt(0) === 97) {
     if (b) {
       return "a-prefix";
+    } else if (input.slice(1) === "") {
+      return "exact-a";
     } else {
-      let $ = input.slice(1);
-      if ($ === "") {
-        return "exact-a";
-      } else {
-        return "other";
-      }
+      return "other";
     }
   } else {
     return "other";

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__strings__string_prefix_rest_is_not_recomputed_for_a_single_check.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__strings__string_prefix_rest_is_not_recomputed_for_a_single_check.snap
@@ -1,6 +1,6 @@
 ---
 source: compiler-core/src/javascript/tests/strings.rs
-expression: "\npub fn classify(input: String, a: Bool, b: Bool) -> String {\n  case input {\n    \"aa\" <> _ if a -> \"aa\"\n    \"a\" <> _ if b -> \"a-guard\"\n    \"ac\" <> _ -> \"ac\"\n    _ -> \"other\"\n  }\n}\n"
+expression: "\npub fn classify(input: String, a: Bool, b: Bool) -> String {\n  case input {\n    \"aa\" <> _ if a -> \"aa\"\n    \"a\" <> _ if b -> \"a-guard\"\n    \"ac\" <> r -> r\n    _ -> \"other\"\n  }\n}\n"
 ---
 ----- SOURCE CODE
 
@@ -8,7 +8,7 @@ pub fn classify(input: String, a: Bool, b: Bool) -> String {
   case input {
     "aa" <> _ if a -> "aa"
     "a" <> _ if b -> "a-guard"
-    "ac" <> _ -> "ac"
+    "ac" <> r -> r
     _ -> "other"
   }
 }
@@ -21,10 +21,14 @@ export function classify(input, a, b) {
   } else if (input.charCodeAt(0) === 97) {
     if (b) {
       return "a-guard";
-    } else if (input.slice(1).charCodeAt(0) === 99) {
-      return "ac";
     } else {
-      return "other";
+      let $ = input.slice(1);
+      if ($.charCodeAt(0) === 99) {
+        let r = $.slice(1);
+        return r;
+      } else {
+        return "other";
+      }
     }
   } else {
     return "other";

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__strings__string_prefix_rest_is_not_recomputed_when_used_by_guard.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__strings__string_prefix_rest_is_not_recomputed_when_used_by_guard.snap
@@ -1,0 +1,37 @@
+---
+source: compiler-core/src/javascript/tests/strings.rs
+expression: "\npub fn go(input: String, b: Bool) -> String {\n  case input {\n    \"a\" <> _ if b -> \"a-guard\"\n    \"ac\" <> r if r != \"\" -> \"ac\" <> r\n    _ -> \"other\"\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn go(input: String, b: Bool) -> String {
+  case input {
+    "a" <> _ if b -> "a-guard"
+    "ac" <> r if r != "" -> "ac" <> r
+    _ -> "other"
+  }
+}
+
+
+----- COMPILED JAVASCRIPT
+export function go(input, b) {
+  if (input.charCodeAt(0) === 97) {
+    if (b) {
+      return "a-guard";
+    } else {
+      let $ = input.slice(1);
+      if ($.charCodeAt(0) === 99) {
+        let r = $.slice(1);
+        if (r !== "") {
+          return input;
+        } else {
+          return "other";
+        }
+      } else {
+        return "other";
+      }
+    }
+  } else {
+    return "other";
+  }
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__tuples__nested_pattern.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__tuples__nested_pattern.snap
@@ -14,8 +14,7 @@ pub fn go(x) {
 
 ----- COMPILED JAVASCRIPT
 export function go(x) {
-  let $ = x[0];
-  if ($ === 2) {
+  if (x[0] === 2) {
     let a = x[1][0];
     let b = x[1][1];
     return a + b;

--- a/compiler-core/src/javascript/tests/strings.rs
+++ b/compiler-core/src/javascript/tests/strings.rs
@@ -436,3 +436,34 @@ pub fn classify(input: String) -> String {
 "#,
     );
 }
+
+#[test]
+fn string_prefix_rest_is_not_recomputed_for_a_single_check() {
+    assert_js!(
+        r#"
+pub fn classify(input: String, a: Bool, b: Bool) -> String {
+  case input {
+    "aa" <> _ if a -> "aa"
+    "a" <> _ if b -> "a-guard"
+    "ac" <> r -> r
+    _ -> "other"
+  }
+}
+"#,
+    );
+}
+
+#[test]
+fn string_prefix_rest_is_not_recomputed_when_used_by_guard() {
+    assert_js!(
+        r#"
+pub fn go(input: String, b: Bool) -> String {
+  case input {
+    "a" <> _ if b -> "a-guard"
+    "ac" <> r if r != "" -> "ac" <> r
+    _ -> "other"
+  }
+}
+"#,
+    );
+}


### PR DESCRIPTION
This is another item I noticed while investigating #6079 that seemed like a nice optimization. The code generator was very conservative about creating a binding for values, even if they were only ever used once. This prevented the existing if merging from creating a better condition. For example, this code:

```gleam
pub fn go(x) {
  case x {
    Wibble(1, 2) -> 1
    _ -> 2
  }
}
```

Currently generates

```javascript
export function go(x) {
  if (x instanceof Wibble) {
    let $ = x[0];
    if ($ === 1) {
      let $1 = x[1];
      if ($1 === 2) {
        return 1;
      } else {
        return 2;
      }
    } else {
      return 2;
    }
  } else {
    return 2;
  }
}
```

But with this change, it now generates

```javascript
export function go(x) {
  if (x instanceof Wibble && x[0] === 1 && x[1] === 2) {
    return 1;
  } else {
    return 2;
  }
}
```

The change explores how many times a value is used, and if it is ever used more than once, a binding is still preferred. That way, more expensive operations like string slices aren't duplicated.

- [ ] The changes in this PR have been discussed beforehand in an issue
- [ ] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes
