### PR TITLE
Move v1.18.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,10 +52,3 @@
 - Fixed a bug where the `echo` on the JavaScript target would incorrectly print
   `NaN` and `Infinity`.
   ([Andrey Kozhev](https://github.com/ankddev))
-
-## v1.18.1 - 2026-08-01
-
-- Fixed a bug where the Erlang code generator would generate wrong code when
-  referencing constants that are aliases to other constants in bit array
-  segments, string concatenation and clause guards.
-  ([Andrey Kozhev](https://github.com/ankddev))

--- a/changelog/v1.18.md
+++ b/changelog/v1.18.md
@@ -5,6 +5,15 @@
 
 # Changelog
 
+## v1.18.1 - 2026-08-01
+
+### Bug fixes
+
+- Fixed a bug where the Erlang code generator would generate wrong code when
+  referencing constants that are aliases to other constants in bit array
+  segments, string concatenation and clause guards.
+  ([Andrey Kozhev](https://github.com/ankddev))
+
 ## v1.18.0 - 2026-07-29
 
 ### Bug fixes


### PR DESCRIPTION
I noticed that v1.18.1 changelog was still in `CHANGELOG.md`, so this PR moves it to `changelogs/v1.18.md`. And I also added missing sub-header.

- [ ] The changes in this PR have been discussed beforehand in an issue
- [ ] The issue for this PR has been linked
- [ ] Tests have been added for new behaviour
- [ ] The changelog has been updated for any user-facing changes
