### PR TITLE
Feat: deprecate `[..x]` spread pattern in case clauses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@
 
 ### Compiler
 
+- The compiler now emits a warning when trying to use the pattern of a spread
+  and a variable when pattern matching inside a 'case' clause.
+  This syntax may be removed in a future (major) release.
+
+  Considering the following Gleam code:
+
+  ```gleam
+  pub fn main() {
+    let letters = ["b", "c"]
+    case letters {
+      [] -> []
+      [..x] -> x
+    }
+  }
+  ```
+
+  The compiler will emit the following warning:
+
+  ```txt
+  warning: Deprecated list pattern matching syntax
+    ┌─ /main.gleam:6:9
+    │
+  6 │         [..x] -> x
+    │         ^^^^^ This can be replaced with the variable itself
+  ```
+
+  ([Khalid Belkassmi E.H.](https://github.com/khalidbelk))
+
 - When compiling to JavaScript any case clauses found to be unreachable will no
   longer generate any code.
   ([Jack Programs](https://github.com/jackprogramsjp))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,35 @@
   longer generate any code.
   ([Jack Programs](https://github.com/jackprogramsjp))
 
+- The compiler now emits a warning when trying to use the pattern of a spread
+  and a variable when pattern matching inside a 'case' clause.
+  This syntax may be removed in a future (major) release.
+
+  Considering the following Gleam code:
+
+  ```gleam
+  pub fn main() {
+    let letters = ["b", "c"]
+    case letters {
+      [] -> []
+      [..x] -> x
+    }
+  }
+  ```
+
+  The compiler will emit the following warning:
+
+  ```txt
+  warning: Deprecated list pattern matching syntax
+    ┌─ /main.gleam:6:9
+    │
+  6 │         [..x] -> x
+    │         ^^^^^ This can be replaced with the variable itself
+  ```
+
+  ([Khalid Belkassmi E.H.](https://github.com/khalidbelk))
+
+
 - The compiler now has a specific error message for when trying to use
   procedural operators that do not exist in Gleam, such as `+=` and `++`.
   ([0xda157](https://github.com/0xda157))

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -1612,10 +1612,11 @@ where
                                 DeprecatedSyntaxWarning::DeprecatedListCatchAllPattern { location },
                             );
                         }
-                        Some(Pattern::Variable { .. }) => {
+                        Some(Pattern::Variable { name, .. }) => {
                             self.warnings.push(
                                 DeprecatedSyntaxWarning::DeprecatedListSpreadAsVariablePattern {
                                     location,
+                                    name: name.clone(),
                                 },
                             );
                         }

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -1603,20 +1603,17 @@ where
                     };
 
                     match tail.as_ref() {
-                        Some(pattern) => {
-                            if pattern.is_discard() {
-                                self.warnings.push(
-                                    DeprecatedSyntaxWarning::DeprecatedListCatchAllPattern {
-                                        location,
-                                    },
-                                );
-                            } else if pattern.is_variable() {
-                                self.warnings.push(
-                                    DeprecatedSyntaxWarning::DeprecatedListSpreadAsVariablePattern {
-                                        location,
-                                    }
-                                );
-                            }
+                        Some(Pattern::Discard { .. }) => {
+                            self.warnings.push(
+                                DeprecatedSyntaxWarning::DeprecatedListCatchAllPattern { location },
+                            );
+                        }
+                        Some(Pattern::Variable { .. }) => {
+                            self.warnings.push(
+                                DeprecatedSyntaxWarning::DeprecatedListSpreadAsVariablePattern {
+                                    location,
+                                },
+                            );
                         }
                         _ => {}
                     }

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -1600,15 +1600,30 @@ where
                     None => None,
                 };
 
-                if elements.is_empty() && tail.as_ref().is_some_and(|pattern| pattern.is_discard())
-                {
-                    self.warnings
-                        .push(DeprecatedSyntaxWarning::DeprecatedListCatchAllPattern {
-                            location: SrcSpan {
-                                start,
-                                end: closing_square_bracket_end,
-                            },
-                        });
+                if elements.is_empty() {
+                    let location = SrcSpan {
+                        start,
+                        end: closing_square_bracket_end,
+                    };
+
+                    match tail.as_ref() {
+                        Some(pattern) => {
+                            if pattern.is_discard() {
+                                self.warnings.push(
+                                    DeprecatedSyntaxWarning::DeprecatedListCatchAllPattern {
+                                        location,
+                                    },
+                                );
+                            } else if pattern.is_variable() {
+                                self.warnings.push(
+                                    DeprecatedSyntaxWarning::DeprecatedListSpreadAsVariablePattern {
+                                        location,
+                                    }
+                                );
+                            }
+                        }
+                        _ => {}
+                    }
                 }
 
                 Pattern::List {

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -1607,20 +1607,17 @@ where
                     };
 
                     match tail.as_ref() {
-                        Some(pattern) => {
-                            if pattern.is_discard() {
-                                self.warnings.push(
-                                    DeprecatedSyntaxWarning::DeprecatedListCatchAllPattern {
-                                        location,
-                                    },
-                                );
-                            } else if pattern.is_variable() {
-                                self.warnings.push(
-                                    DeprecatedSyntaxWarning::DeprecatedListSpreadAsVariablePattern {
-                                        location,
-                                    }
-                                );
-                            }
+                        Some(Pattern::Discard { .. }) => {
+                            self.warnings.push(
+                                DeprecatedSyntaxWarning::DeprecatedListCatchAllPattern { location },
+                            );
+                        }
+                        Some(Pattern::Variable { .. }) => {
+                            self.warnings.push(
+                                DeprecatedSyntaxWarning::DeprecatedListSpreadAsVariablePattern {
+                                    location,
+                                },
+                            );
                         }
                         _ => {}
                     }

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -1596,15 +1596,30 @@ where
                     None => None,
                 };
 
-                if elements.is_empty() && tail.as_ref().is_some_and(|pattern| pattern.is_discard())
-                {
-                    self.warnings
-                        .push(DeprecatedSyntaxWarning::DeprecatedListCatchAllPattern {
-                            location: SrcSpan {
-                                start,
-                                end: closing_square_bracket_end,
-                            },
-                        });
+                if elements.is_empty() {
+                    let location = SrcSpan {
+                        start,
+                        end: closing_square_bracket_end,
+                    };
+
+                    match tail.as_ref() {
+                        Some(pattern) => {
+                            if pattern.is_discard() {
+                                self.warnings.push(
+                                    DeprecatedSyntaxWarning::DeprecatedListCatchAllPattern {
+                                        location,
+                                    },
+                                );
+                            } else if pattern.is_variable() {
+                                self.warnings.push(
+                                    DeprecatedSyntaxWarning::DeprecatedListSpreadAsVariablePattern {
+                                        location,
+                                    }
+                                );
+                            }
+                        }
+                        _ => {}
+                    }
                 }
 
                 Pattern::List {

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__deprecated_list_pattern_syntax_1.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__deprecated_list_pattern_syntax_1.snap
@@ -18,7 +18,7 @@ warning: Deprecated list pattern matching syntax
   ┌─ test/path:6:9
   │
 6 │         [..] -> []
-  │         ^^^^ This can be replaced with `_`
+  │         ^^^^ Replace this with `_`
 
 This syntax for pattern matching on lists is deprecated.
 To match on all possible lists, use the `_` catch-all pattern instead.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__deprecated_list_spread_variable_pattern_syntax.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__deprecated_list_spread_variable_pattern_syntax.snap
@@ -1,25 +1,25 @@
 ---
 source: compiler-core/src/type_/tests/warnings.rs
-expression: "\n    pub fn main() {\n      let letters = [\"b\", \"c\"]\n      case letters {\n        [] -> []\n        [..x] -> x\n      }\n    }\n        "
+expression: "\npub fn main() {\n  let letters = [\"b\", \"c\"]\n  case letters {\n    [] -> []\n    [..x] -> x\n  }\n}\n"
 ---
 ----- SOURCE CODE
 
-    pub fn main() {
-      let letters = ["b", "c"]
-      case letters {
-        [] -> []
-        [..x] -> x
-      }
-    }
-        
+pub fn main() {
+  let letters = ["b", "c"]
+  case letters {
+    [] -> []
+    [..x] -> x
+  }
+}
+
 
 ----- WARNING
 warning: Deprecated list pattern matching syntax
-  ┌─ test/path:6:9
+  ┌─ test/path:6:5
   │
-6 │         [..x] -> x
-  │         ^^^^^ This can be replaced with the variable itself
+6 │     [..x] -> x
+  │     ^^^^^ Replace this with `x`
 
 This syntax for pattern matching on lists is deprecated.
-This spread matches the entire list, so the variable can be used as the
+This spread matches the entire list, so the variable x can be used as the
 pattern directly instead.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__deprecated_list_spread_variable_pattern_syntax.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__deprecated_list_spread_variable_pattern_syntax.snap
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\n    pub fn main() {\n      let letters = [\"b\", \"c\"]\n      case letters {\n        [] -> []\n        [..x] -> x\n      }\n    }\n        "
+---
+----- SOURCE CODE
+
+    pub fn main() {
+      let letters = ["b", "c"]
+      case letters {
+        [] -> []
+        [..x] -> x
+      }
+    }
+        
+
+----- WARNING
+warning: Deprecated list pattern matching syntax
+  ┌─ test/path:6:9
+  │
+6 │         [..x] -> x
+  │         ^^^^^ This can be replaced with the variable itself
+
+This syntax for pattern matching on lists is deprecated.
+This spread matches the entire list, so the variable can be used as the
+pattern directly instead.

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -2328,18 +2328,19 @@ fn deprecated_list_pattern_syntax_1() {
     );
 }
 
+// https://github.com/gleam-lang/gleam/issues/6088
 #[test]
 fn deprecated_list_spread_variable_pattern_syntax() {
     assert_warning!(
         r#"
-    pub fn main() {
-      let letters = ["b", "c"]
-      case letters {
-        [] -> []
-        [..x] -> x
-      }
-    }
-        "#
+pub fn main() {
+  let letters = ["b", "c"]
+  case letters {
+    [] -> []
+    [..x] -> x
+  }
+}
+"#
     );
 }
 

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -2328,6 +2328,21 @@ fn deprecated_list_pattern_syntax_1() {
     );
 }
 
+#[test]
+fn deprecated_list_spread_variable_pattern_syntax() {
+    assert_warning!(
+        r#"
+    pub fn main() {
+      let letters = ["b", "c"]
+      case letters {
+        [] -> []
+        [..x] -> x
+      }
+    }
+        "#
+    );
+}
+
 // https://github.com/gleam-lang/gleam/issues/3473
 #[test]
 fn deprecated_record_pattern_syntax() {

--- a/compiler-core/src/warning.rs
+++ b/compiler-core/src/warning.rs
@@ -188,7 +188,7 @@ pub enum Warning {
     },
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Copy)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum DeprecatedSyntaxWarning {
     /// If someone uses the deprecated syntax to append to a list:
     /// `["a"..rest]`, notice how there's no comma!
@@ -235,6 +235,7 @@ pub enum DeprecatedSyntaxWarning {
     ///
     DeprecatedListSpreadAsVariablePattern {
         location: SrcSpan,
+        name: EcoString,
     },
 
     /// If a record pattern has a spread that is not preceded by a comma:
@@ -365,7 +366,7 @@ To match on all possible lists, use the `_` catch-all pattern instead.",
                 level: diagnostic::Level::Warning,
                 location: Some(Location {
                     label: diagnostic::Label {
-                        text: Some("This can be replaced with `_`".into()),
+                        text: Some("Replace this with `_`".into()),
                         span: *location,
                     },
                     path: path.clone(),
@@ -377,19 +378,20 @@ To match on all possible lists, use the `_` catch-all pattern instead.",
             Warning::DeprecatedSyntax {
                 path,
                 src,
-                warning: DeprecatedSyntaxWarning::DeprecatedListSpreadAsVariablePattern { location },
+                warning:
+                    DeprecatedSyntaxWarning::DeprecatedListSpreadAsVariablePattern { location, name },
             } => Diagnostic {
                 title: "Deprecated list pattern matching syntax".into(),
-                text: wrap(
+                text: wrap_format!(
                     "This syntax for pattern matching on lists is deprecated.
-This spread matches the entire list, so the variable can be used as \
+This spread matches the entire list, so the variable {name} can be used as \
 the pattern directly instead.",
                 ),
                 hint: None,
                 level: diagnostic::Level::Warning,
                 location: Some(Location {
                     label: diagnostic::Label {
-                        text: Some("This can be replaced with the variable itself".into()),
+                        text: Some(format!("Replace this with `{name}`")),
                         span: *location,
                     },
                     path: path.clone(),

--- a/compiler-core/src/warning.rs
+++ b/compiler-core/src/warning.rs
@@ -223,6 +223,20 @@ pub enum DeprecatedSyntaxWarning {
         location: SrcSpan,
     },
 
+    /// If someone uses the deprecated syntax to bind an entire list to a
+    /// variable with a spread, instead of using the variable directly:
+    /// ```gleam
+    /// case list {
+    ///   [..x] -> todo
+    /// //^^^^^ this matches the whole list so `x` should be used instead!
+    ///   _ ->
+    /// }
+    /// ```
+    ///
+    DeprecatedListSpreadAsVariablePattern {
+        location: SrcSpan,
+    },
+
     /// If a record pattern has a spread that is not preceded by a comma:
     /// ```gleam
     /// case wibble {
@@ -352,6 +366,30 @@ To match on all possible lists, use the `_` catch-all pattern instead.",
                 location: Some(Location {
                     label: diagnostic::Label {
                         text: Some("This can be replaced with `_`".into()),
+                        span: *location,
+                    },
+                    path: path.clone(),
+                    src: src.clone(),
+                    extra_labels: vec![],
+                }),
+            },
+
+            Warning::DeprecatedSyntax {
+                path,
+                src,
+                warning: DeprecatedSyntaxWarning::DeprecatedListSpreadAsVariablePattern { location },
+            } => Diagnostic {
+                title: "Deprecated list pattern matching syntax".into(),
+                text: wrap(
+                    "This syntax for pattern matching on lists is deprecated.
+This spread matches the entire list, so the variable can be used as \
+the pattern directly instead.",
+                ),
+                hint: None,
+                level: diagnostic::Level::Warning,
+                location: Some(Location {
+                    label: diagnostic::Label {
+                        text: Some("This can be replaced with the variable itself".into()),
                         span: *location,
                     },
                     path: path.clone(),

--- a/compiler-core/src/warning.rs
+++ b/compiler-core/src/warning.rs
@@ -222,6 +222,20 @@ pub enum DeprecatedSyntaxWarning {
         location: SrcSpan,
     },
 
+    /// If someone uses the deprecated syntax to bind an entire list to a
+    /// variable with a spread, instead of using the variable directly:
+    /// ```gleam
+    /// case list {
+    ///   [..x] -> todo
+    /// //^^^^^ this matches the whole list so `x` should be used instead!
+    ///   _ ->
+    /// }
+    /// ```
+    ///
+    DeprecatedListSpreadAsVariablePattern {
+        location: SrcSpan,
+    },
+
     /// If a record pattern has a spread that is not preceded by a comma:
     /// ```gleam
     /// case wibble {
@@ -351,6 +365,30 @@ To match on all possible lists, use the `_` catch-all pattern instead.",
                 location: Some(Location {
                     label: diagnostic::Label {
                         text: Some("This can be replaced with `_`".into()),
+                        span: *location,
+                    },
+                    path: path.clone(),
+                    src: src.clone(),
+                    extra_labels: vec![],
+                }),
+            },
+
+            Warning::DeprecatedSyntax {
+                path,
+                src,
+                warning: DeprecatedSyntaxWarning::DeprecatedListSpreadAsVariablePattern { location },
+            } => Diagnostic {
+                title: "Deprecated list pattern matching syntax".into(),
+                text: wrap(
+                    "This syntax for pattern matching on lists is deprecated.
+This spread matches the entire list, so the variable can be used as \
+the pattern directly instead.",
+                ),
+                hint: None,
+                level: diagnostic::Level::Warning,
+                location: Some(Location {
+                    label: diagnostic::Label {
+                        text: Some("This can be replaced with the variable itself".into()),
                         span: *location,
                     },
                     path: path.clone(),

--- a/docs/v2.md
+++ b/docs/v2.md
@@ -5,6 +5,13 @@
 
 # Breaking changes to make for v2
 
+## `[..x]` pattern inside `case` expressions
+
+This pattern is deprecated as it can always be rewritten as the variable itself: use `x` directly instead of `[..x]`.
+
+- [x] Emits warning when used.
+- [x] Formatter rewrites it to desired syntax.
+
 ## `[1 ..]` syntax
 
 Due to a bug in the parser we accept `[1, ..]` as a valid list value.


### PR DESCRIPTION
- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes

Fixes issue #6088
