### PR TITLE
Made error reporting more specific for top-level function calls by reusing existing const assignment error machinery.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
   expression now points to the entire function call.
   ([mmustafasenoglu](https://github.com/mmustafasenoglu))
 
+- The error message for top-level function calls is now the same as top-level 
+  function calls on the right-hand of const assignment.
+  ([jamesdolan16](https://github.com/jamesdolan16))
+
 ### Build tool
 
 - The build tool now stores its build cache in a more compact binary format,

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -282,7 +282,34 @@ where
     ) -> Result<A, ParseError> {
         let parse_result = self.ensure_no_errors(parse_result)?;
         if let Some((start, token, end)) = self.next_token() {
-            // there are still more tokens
+            // there are still more tokens, check to see if we're attempting to call a function from the wrong scope
+            // if we are report that fact to the user, otherwise return generic UnexpectedToken message
+            if let Token::Name { .. } = &token {
+                // Handle module qualifier
+                if let Some((_, Token::Dot, _)) = self.token0 {
+                    self.advance(); // Dot
+                    self.advance(); // Fn name
+                }
+
+                return match self.token0.take() {
+                    Some((_, Token::LeftParen, paren_end)) => {
+                        self.advance(); // Left Paren
+                        self.unexpected_function_call(start, paren_end)
+                    }
+                    Some((start, token, end)) => parse_error(
+                        ParseErrorType::UnexpectedToken {
+                            token,
+                            expected: vec!["Name".into()],
+                            hint: None,
+                        },
+                        SrcSpan { start, end },
+                    ),
+                    None => {
+                        parse_error(ParseErrorType::UnexpectedEof, SrcSpan { start: 0, end: 0 })
+                    }
+                };
+            }
+
             let expected = vec!["An import, const, type, or function.".into()];
             return parse_error(
                 ParseErrorType::UnexpectedToken {
@@ -3540,7 +3567,7 @@ where
                         match self.token0 {
                             Some((_, Token::LeftParen, paren_end)) => {
                                 self.advance();
-                                self.function_call_in_constant(start, paren_end)
+                                self.unexpected_function_call(start, paren_end)
                             }
                             _ => Ok(Some(Constant::Var {
                                 location: SrcSpan { start, end },
@@ -3571,7 +3598,7 @@ where
                 match self.token0 {
                     Some((_, Token::LeftParen, paren_end)) => {
                         self.advance();
-                        self.function_call_in_constant(start, paren_end)
+                        self.unexpected_function_call(start, paren_end)
                     }
                     _ => Ok(Some(Constant::Var {
                         location: SrcSpan { start, end },
@@ -4510,14 +4537,13 @@ functions are declared separately from types.";
         }
     }
 
-    /// This function is to be called after seeing a `name(` in a constant
-    /// or guard clause expression. It returns an error, as functions
-    /// cannot be called in this context.
-    fn function_call_in_constant(
+    /// This function is to be called after seeing a `name(` in an unexpected place. 
+    /// It returns an error, as functions cannot be called from whatever context called this function.
+    fn unexpected_function_call<A>(
         &mut self,
         start: u32,
         start_paren: u32,
-    ) -> Result<Option<Constant<()>>, ParseError> {
+    ) -> Result<A, ParseError> {
         let mut depth: i32 = 1;
 
         // Scan ahead through the token stream to find the matching closing paren.

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__function_call_at_module_scope.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__function_call_at_module_scope.snap
@@ -1,0 +1,16 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "\npub fn wibble() { todo }\nwibble()\n"
+---
+----- SOURCE CODE
+
+pub fn wibble() { todo }
+wibble()
+
+
+----- ERROR
+error: Syntax error
+  ┌─ /src/parse/error.gleam:3:1
+  │
+3 │ wibble()
+  │ ^^^^^^^^ Functions can only be called within other functions

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__module_qualified_function_call_at_module_scope.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__module_qualified_function_call_at_module_scope.snap
@@ -1,0 +1,15 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "\nio.println(\"wibble\")\n"
+---
+----- SOURCE CODE
+
+io.println("wibble")
+
+
+----- ERROR
+error: Syntax error
+  ┌─ /src/parse/error.gleam:2:1
+  │
+2 │ io.println("wibble")
+  │ ^^^^^^^^^^^^^^^^^^^^ Functions can only be called within other functions

--- a/compiler-core/src/parse/tests.rs
+++ b/compiler-core/src/parse/tests.rs
@@ -972,6 +972,25 @@ const wib: Int = wibble(1, "wobble")
 }
 
 #[test]
+fn function_call_at_module_scope() {
+    assert_module_error!(
+        r#"
+pub fn wibble() { todo }
+wibble()
+"#
+    );
+}
+
+#[test]
+fn module_qualified_function_call_at_module_scope() {
+    assert_module_error!(
+        r#"
+io.println("wibble")
+"#
+    );
+}
+
+#[test]
 fn import_type() {
     assert_parse_module!(r#"import wibble.{type Wobble, Wobble, type Wabble}"#);
 }


### PR DESCRIPTION
Refactored existing call in const assignment error function to more generic form 'UnexpectedFunction', allowing for broader use in an easy to understand manner.

Then, added a check to generate this error when parsing the tokens remaining after declarations, by spotting whether there is a function call, or module qualified function call where there shouldn't be. The previous behaviour is preserved if this check fails.


- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes
