### PR TITLE
Stopped unknown type errors cascading through usages when an invalid type alias is created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
   expression now points to the entire function call.
   ([mmustafasenoglu](https://github.com/mmustafasenoglu))
 
+- When an invalid type alias is created the error messages no longer cascade 
+  through further usages.
+  ([James Dolan](https://github.com/jamesdolan16))
+
 ### Build tool
 
 - The build tool now stores its build cache in a more compact binary format,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,10 @@
 
   ([Andrey Kozhev](https://github.com/ankddev))
 
+- When an invalid type alias is created the error messages no longer cascade
+  through further usages.
+  ([James Dolan](https://github.com/jamesdolan16))
+
 ### Build tool
 
 - The build tool now stores its build cache in a more compact binary format,

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -1499,7 +1499,14 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
         let arity = parameters.len();
         let tryblock = || {
             hydrator.disallow_new_type_variables();
-            let type_ = hydrator.type_from_ast(resolved_type, environment, &mut self.problems)?;
+            let hydrator_result =
+                hydrator.type_from_ast(resolved_type, environment, &mut self.problems);
+
+            let type_ = match &hydrator_result {
+                Ok(type_) => type_.clone(),
+                Err(Error::UnknownType { .. }) => environment.new_unbound_var(),
+                Err(e) => return Err(e.clone()),
+            };
 
             environment
                 .names
@@ -1545,7 +1552,11 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
                 });
             }
 
-            Ok(())
+            if let Err(e) = hydrator_result {
+                Err(e)
+            } else {
+                Ok(())
+            }
         };
         let result = tryblock();
         self.record_if_error(result);

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -1487,8 +1487,7 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
 
             let type_ = match &hydrator_result {
                 Ok(type_) => type_.clone(),
-                Err(Error::UnknownType { .. }) => environment.new_unbound_var(),
-                Err(e) => return Err(e.clone()),
+                Err(_) => environment.new_unbound_var(),
             };
 
             environment

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -1482,7 +1482,14 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
         let arity = parameters.len();
         let tryblock = || {
             hydrator.disallow_new_type_variables();
-            let type_ = hydrator.type_from_ast(resolved_type, environment, &mut self.problems)?;
+            let hydrator_result =
+                hydrator.type_from_ast(resolved_type, environment, &mut self.problems);
+
+            let type_ = match &hydrator_result {
+                Ok(type_) => type_.clone(),
+                Err(Error::UnknownType { .. }) => environment.new_unbound_var(),
+                Err(e) => return Err(e.clone()),
+            };
 
             environment
                 .names
@@ -1528,7 +1535,11 @@ impl<'a, A> ModuleAnalyzer<'a, A> {
                 });
             }
 
-            Ok(())
+            if let Err(e) = hydrator_result {
+                Err(e)
+            } else {
+                Ok(())
+            }
         };
         let result = tryblock();
         self.record_if_error(result);

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__type_alias__aliasing_of_unknown_type.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__type_alias__aliasing_of_unknown_type.snap
@@ -1,0 +1,18 @@
+---
+source: compiler-core/src/type_/tests/type_alias.rs
+expression: "\npub type UnknownAlias = UnknownType\npub type UsageOfUnknownAlias = UnknownAlias\n"
+---
+----- SOURCE CODE
+
+pub type UnknownAlias = UnknownType
+pub type UsageOfUnknownAlias = UnknownAlias
+
+
+----- ERROR
+error: Unknown type
+  ┌─ /src/one/two.gleam:2:25
+  │
+2 │ pub type UnknownAlias = UnknownType
+  │                         ^^^^^^^^^^^
+
+The type `UnknownType` is not defined or imported in this module.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__type_alias__invalid_alias_error_shows_root_cause_without_cascading.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__type_alias__invalid_alias_error_shows_root_cause_without_cascading.snap
@@ -20,11 +20,3 @@ error: Unknown type
   │        ^^^^ Did you mean `Int`?
 
 The type `Intt` is not defined or imported in this module.
-
-error: Unknown type
-  ┌─ /src/one/two.gleam:5:15
-  │
-5 │ fn example(a: X) {
-  │               ^
-
-The type `X` is not defined or imported in this module.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__type_alias__multiple_aliases_of_unknown_type.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__type_alias__multiple_aliases_of_unknown_type.snap
@@ -1,0 +1,20 @@
+---
+source: compiler-core/src/type_/tests/type_alias.rs
+expression: "\npub type UnknownAlias = UnknownType\n\npub type One = List(UnknownAlias)\npub type Two = Result(UnknownAlias, Nil)\n"
+---
+----- SOURCE CODE
+
+pub type UnknownAlias = UnknownType
+
+pub type One = List(UnknownAlias)
+pub type Two = Result(UnknownAlias, Nil)
+
+
+----- ERROR
+error: Unknown type
+  ┌─ /src/one/two.gleam:2:25
+  │
+2 │ pub type UnknownAlias = UnknownType
+  │                         ^^^^^^^^^^^
+
+The type `UnknownType` is not defined or imported in this module.

--- a/compiler-core/src/type_/tests/type_alias.rs
+++ b/compiler-core/src/type_/tests/type_alias.rs
@@ -124,11 +124,12 @@ type UnknownType =
     );
 }
 
-// https://github.com/gleam-lang/gleam/issues/3191
+// Original:        https://github.com/gleam-lang/gleam/issues/3191
+// Superceded by:   https://github.com/gleam-lang/gleam/issues/6072
 #[test]
-fn both_errors_are_shown() {
-    // The alias has an error, and it causes the function to have an error as it
-    // refers to the type that does not exist.
+fn invalid_alias_error_shows_root_cause_without_cascading() {
+    // The alias has an error which gets reported, but using that alias 
+    // should not generate a further UnknownType error
     assert_module_error!(
         r#"
 type X =
@@ -147,5 +148,27 @@ fn conflict_with_import() {
     assert_module_error!(
         ("wibble", "pub type Wobble = String"),
         "import wibble.{type Wobble} type Wobble = Int",
+    );
+}
+
+#[test]
+fn aliasing_of_unknown_type() {
+    assert_module_error!(
+        r#"
+pub type UnknownAlias = UnknownType
+pub type UsageOfUnknownAlias = UnknownAlias
+"#
+    );
+}
+
+#[test]
+fn multiple_aliases_of_unknown_type() {
+    assert_module_error!(
+        r#"
+pub type UnknownAlias = UnknownType
+
+pub type One = List(UnknownAlias)
+pub type Two = Result(UnknownAlias, Nil)
+"#
     );
 }

--- a/compiler-core/src/type_/tests/type_alias.rs
+++ b/compiler-core/src/type_/tests/type_alias.rs
@@ -128,7 +128,7 @@ type UnknownType =
 // Superceded by:   https://github.com/gleam-lang/gleam/issues/6072
 #[test]
 fn invalid_alias_error_shows_root_cause_without_cascading() {
-    // The alias has an error which gets reported, but using that alias 
+    // The alias has an error which gets reported, but using that alias
     // should not generate a further UnknownType error
     assert_module_error!(
         r#"


### PR DESCRIPTION
Fixes https://github.com/gleam-lang/gleam/issues/6072;

Modified the code that registers type aliases so that when a type constructor cannot be found, instead of returning an error straight away, we use a new unbound type var for that alias, allowing later usages to remain valid thereby getting rid of the cascading unknown type error messages.

Also refactored the `both_errors_are_shown` test, as it appears that was there to ensure a previous fix related to this outputted a sensible error, which at the time was deemed to be the cascading behaviour. As this fix overrides that behaviour with the root cause/non-cascading message, I felt the test should be updated to reflect this.

- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes
