### PR TITLE
fix: provide helpful error message when record update spread comes after fields

### DIFF
--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -993,6 +993,20 @@ where
                             _ => {
                                 // Call
                                 let arguments = self.parse_fn_arguments()?;
+                                // Check if the user wrote a record update with the spread
+                                // after the fields, like `Wibble(two: 2, ..wibble)` instead
+                                // of `Wibble(..wibble, two: 2)`
+                                if let Some((dot_start, Token::DotDot, dot_end)) = self.token0 {
+                                    if !arguments.is_empty() {
+                                        return Err(parse_error(
+                                            ParseErrorType::RecordUpdateAfterFields,
+                                            SrcSpan {
+                                                start: dot_start,
+                                                end: dot_end,
+                                            },
+                                        ));
+                                    }
+                                }
                                 let (_, end) = self.expect_one(&Token::RightParen)?;
                                 expr = make_call(expr, arguments, start, end, left_paren)?;
                             }

--- a/compiler-core/src/parse/error.rs
+++ b/compiler-core/src/parse/error.rs
@@ -191,6 +191,9 @@ pub enum ParseErrorType {
     },
     // `const x = todo as` with no message after the `as`.
     MissingConstantAsMessage,
+    // When the spread in a record update comes after the fields, like:
+    // `Wibble(two: 2, ..wibble)` instead of `Wibble(..wibble, two: 2)`
+    RecordUpdateAfterFields,
 }
 
 pub(crate) struct ParseErrorDetails {
@@ -797,6 +800,18 @@ See: https://tour.gleam.run/flow-control/case-expressions/"
                 text: "".into(),
                 hint: None,
                 label_text: "I was expecting to see a constant expression after this `as`".into(),
+                extra_labels: vec![],
+            },
+
+            ParseErrorType::RecordUpdateAfterFields => ParseErrorDetails {
+                text: "".into(),
+                hint: Some(
+                    "When updating a record, the spread (`..`) must come before \
+the fields to change, like: `Constructor(..record, field: value)`.\n\
+See https://tour.gleam.run/data-types/record-updates/"
+                        .into(),
+                ),
+                label_text: "I was not expecting a record update here".into(),
                 extra_labels: vec![],
             },
 

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__record_update_spread_after_fields.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__record_update_spread_after_fields.snap
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/parse/tests.rs
+expression: "\npub type Wibble {\n  Wibble(one: Int, two: Int)\n}\n\npub fn main() {\n  let wibble = Wibble(one: 1, two: 2)\n  Wibble(two: 3, ..wibble)\n}\n"
+---
+----- SOURCE CODE
+pub type Wibble {
+  Wibble(one: Int, two: Int)
+}
+
+pub fn main() {
+  let wibble = Wibble(one: 1, two: 2)
+  Wibble(two: 3, ..wibble)
+}
+
+----- ERROR
+error: Syntax error
+  ┌─ /src/parse/error.gleam:7:16
+  │
+7 │   Wibble(two: 3, ..wibble)
+  │                 ^^ I was not expecting a record update here
+
+When updating a record, the spread (`..`) must come before the fields to change.
+Try: `Constructor(..record, field: value)` instead.
+
+See https://tour.gleam.run/data-types/record-updates/

--- a/compiler-core/src/parse/tests.rs
+++ b/compiler-core/src/parse/tests.rs
@@ -2548,3 +2548,20 @@ pub type Wibble {
 "#
     );
 }
+
+#[test]
+fn record_update_spread_after_fields() {
+    // https://github.com/gleam-lang/gleam/issues/6132
+    assert_module_error!(
+        r#"
+pub type Wibble {
+  Wibble(one: Int, two: Int)
+}
+
+pub fn main() {
+  let wibble = Wibble(one: 1, two: 2)
+  Wibble(two: 3, ..wibble)
+}
+"#
+    );
+}


### PR DESCRIPTION
Closes #6132

When a record update is written with the spread after the fields, like `Wibble(two: 2, ..wibble)` instead of `Wibble(..wibble, two: 2)`, the parser now detects this and provides a helpful error message directing the user to the correct syntax.

**Before:**
```
error: Syntax error
  ┌─ src/demo.gleam:7:31
  │
7 │   let wobble = Wibble(two: 2, ..wibble)
  │                               ^^ I was not expecting this

Found `..`, expected one of:
- `)
```

**After:**
```
error: Syntax error
  ┌─ src/demo.gleam:7:31
  │
7 │   let wobble = Wibble(two: 2, ..wibble)
  │                               ^^ I was not expecting a record update here

When updating a record, the spread (`..`) must come before the fields to change.
Try: `Constructor(..record, field: value)` instead.

See https://tour.gleam.run/data-types/record-updates/
```

Changes:
- `compiler-core/src/parse.rs`: Added check in call branch to detect `..` after parsed arguments
- `compiler-core/src/parse/error.rs`: Added `RecordUpdateAfterFields` error type with hint
- `compiler-core/src/parse/tests.rs`: Added regression test