### PR TITLE
fix: show non-printable binaries as bit arrays in echo output

### DIFF
--- a/compiler-core/templates/echo.erl
+++ b/compiler-core/templates/echo.erl
@@ -84,11 +84,21 @@ inspect@bit_array_pieces(Bits, Acc) ->
 inspect@binary(Binary) ->
     case inspect@maybe_utf8_string(Binary, <<>>) of
         {ok, InspectedUtf8String} ->
-            InspectedUtf8String;
+            case inspect@has_printable(Binary) of
+                true -> InspectedUtf8String;
+                false ->
+                    Segments = [erlang:integer_to_list(X) || <<X>> <= Binary],
+                    ["<<", lists:join(", ", Segments), ">>"]
+            end;
         {error, not_a_utf8_string} ->
             Segments = [erlang:integer_to_list(X) || <<X>> <= Binary],
             ["<<", lists:join(", ", Segments), ">>"]
     end.
+
+inspect@has_printable(<<>>) -> false;
+inspect@has_printable(<<C, Rest/binary>>) when C >= 32, C =< 126 -> true;
+inspect@has_printable(<<C, Rest/binary>>) when C == $\n; C == $\r; C == $\t; C == $\f -> true;
+inspect@has_printable(<<_, Rest/binary>>) -> inspect@has_printable(Rest).
 
 inspect@atom(Atom) ->
     Binary = erlang:atom_to_binary(Atom),


### PR DESCRIPTION
Closes #6040

In Erlang, strings and bit arrays share the same runtime representation. The current `echo` implementation eagerly tries to display binaries as UTF-8 strings, which means bit arrays like `<<1, 2, 3>>` get printed as `"\u{0001}\u{0002}\u{0003}"`.

This changes the heuristic: a binary is only displayed as a string if it contains at least one printable character (ASCII 32-126, newline, carriage return, tab, or form feed). Non-printable binaries are shown as bit arrays.

**Before:**
```gleam
echo(<<1, 2, 3>>)
// "\u{0001}\u{0002}\u{0003}"
```

**After:**
```gleam
echo(<<1, 2, 3>>)
// <<1, 2, 3>>
```

Changes:
- `compiler-core/templates/echo.erl`: Added `inspect@has_printable` check in `inspect@binary` to only display as string when the binary contains printable characters