### PR TITLE
Added variant narrowing for constants within their module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
   expression now points to the entire function call.
   ([mmustafasenoglu](https://github.com/mmustafasenoglu))
 
+- Constants that are assigned a type variant are now narrowed within the module they
+  were defined.
+  ([James Dolan](https://github.com/jamesdolan16))
+
 ### Build tool
 
 - The build tool now stores its build cache in a more compact binary format,

--- a/compiler-core/src/analyse.rs
+++ b/compiler-core/src/analyse.rs
@@ -1880,7 +1880,17 @@ fn generalise_module_constant(
         deprecation,
         implementations,
     } = constant;
+
+    let inferred_variant = type_.custom_type_inferred_variant();
+
     let type_ = type_::generalise(type_);
+
+    let mut environment_type = type_.clone();
+
+    if let Some(inferred_variant) = inferred_variant {
+        Arc::make_mut(&mut environment_type).set_custom_type_variant(inferred_variant);
+    }
+
     let variant = ValueConstructorVariant::ModuleConstant {
         documentation: doc.as_ref().map(|(_, doc)| doc.clone()),
         location,
@@ -1892,7 +1902,7 @@ fn generalise_module_constant(
     environment.insert_variable(
         name.clone(),
         variant.clone(),
-        type_.clone(),
+        environment_type,
         publicity,
         deprecation.clone(),
     );

--- a/compiler-core/src/type_/tests/custom_types.rs
+++ b/compiler-core/src/type_/tests/custom_types.rs
@@ -223,3 +223,50 @@ fn handle_fish(fish: Fish) {
 "#
     );
 }
+
+#[test]
+fn narrow_const_variant() {
+    assert_module_infer!(
+        "
+pub type Ty {
+  StrVar(str: String)
+  IntVar(int: Int)
+}
+
+pub const foo = IntVar(42)
+
+pub fn main() {
+  foo.int
+}
+",
+        vec![
+          ("IntVar", "fn(Int) -> Ty"),
+          ("StrVar", "fn(String) -> Ty"),
+          ("foo", "Ty"),
+          ("main", "fn() -> Int")
+        ],
+    );
+}
+
+#[test]
+fn const_variant_narrowing_is_not_public() {
+  assert_module_error!(
+    (
+      "other/module",
+      "
+pub type Ty { 
+  IntVar(int: Int)
+  StrVar(str: String)
+}
+pub const foobar = IntVar(42)
+"
+    ),
+    "
+import other/module
+
+pub fn main() {
+  module.foobar.int
+}
+"
+  );
+}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__custom_types__const_variant_narrowing_is_not_public.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__custom_types__const_variant_narrowing_is_not_public.snap
@@ -1,0 +1,35 @@
+---
+source: compiler-core/src/type_/tests/custom_types.rs
+expression: "\nimport other/module\n\npub fn main() {\n  module.foobar.int\n}\n"
+---
+----- SOURCE CODE
+-- other/module.gleam
+
+pub type Ty { 
+  IntVar(int: Int)
+  StrVar(str: String)
+}
+pub const foobar = IntVar(42)
+
+
+-- main.gleam
+
+import other/module
+
+pub fn main() {
+  module.foobar.int
+}
+
+
+----- ERROR
+error: Unknown record field
+  ┌─ /src/one/two.gleam:5:17
+  │
+5 │   module.foobar.int
+  │                 ^^^ This field does not exist
+
+The value being accessed has this type:
+
+    module.Ty
+
+It does not have any fields.


### PR DESCRIPTION
fixes #5310 

Added functionality to `generalise_module_constant` that captures the inferred variant and then reapplies it to the environments copy of the generalised type. This allows for the inferred variant to carry forward within the module scope that the const was defined.

- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes
