### PR TITLE
Better errors and formatting for binops in constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,29 @@
 
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- The compiler is now fault tolerant when it runs into unsupported binary
+  operators used in constants. Instead than stopping to analyse the whole module
+  the compiler now produces an error message explaining the operator is not
+  supported. For example:
+
+  ```gleam
+  pub const wibble = 1.1 *. 11.0
+  ```
+
+  Results in the following error:
+
+  ```
+  error: Unsupported operator in constant expression
+    ┌─ /Users/giacomocavalieri/Desktop/prova/src/prova.gleam:1:24
+    │
+  1 │ pub const wibble = 1.1 *. 11.0
+    │                        ^^
+
+  This operator is currently not supported in constants.
+  ```
+
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Build tool
 
 - The build tool now stores its build cache in a more compact binary format,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,10 @@
   types with a same-named import alias.
   ([Andrey Kozhev](https://github.com/ankddev))
 
+- Fixed a bug where comments after the last item in a tuple, or after the last
+  argument in a function call wouldn't be formatted properly.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ## v1.18.1 - 2026-08-01
 
 - Fixed a bug where the Erlang code generator would generate wrong code when

--- a/compiler-core/src/ast.rs
+++ b/compiler-core/src/ast.rs
@@ -1359,7 +1359,7 @@ impl Layer {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum BinOp {
     // Boolean logic
     And,

--- a/compiler-core/src/ast/constant.rs
+++ b/compiler-core/src/ast/constant.rs
@@ -144,6 +144,42 @@ impl<T> Constant<T> {
             None
         }
     }
+
+    pub fn is_tuple(&self) -> bool {
+        match self {
+            Constant::Tuple { .. } => true,
+
+            Constant::Int { .. }
+            | Constant::Float { .. }
+            | Constant::String { .. }
+            | Constant::List { .. }
+            | Constant::Record { .. }
+            | Constant::RecordUpdate { .. }
+            | Constant::BitArray { .. }
+            | Constant::Var { .. }
+            | Constant::BinaryOperator { .. }
+            | Constant::Invalid { .. }
+            | Constant::Todo { .. } => false,
+        }
+    }
+
+    pub fn is_binop(&self) -> bool {
+        match self {
+            Constant::BinaryOperator { .. } => true,
+
+            Constant::Tuple { .. }
+            | Constant::Int { .. }
+            | Constant::Float { .. }
+            | Constant::String { .. }
+            | Constant::List { .. }
+            | Constant::Record { .. }
+            | Constant::RecordUpdate { .. }
+            | Constant::BitArray { .. }
+            | Constant::Var { .. }
+            | Constant::Invalid { .. }
+            | Constant::Todo { .. } => false,
+        }
+    }
 }
 
 impl TypedConstant {

--- a/compiler-core/src/ast/constant.rs
+++ b/compiler-core/src/ast/constant.rs
@@ -88,10 +88,17 @@ pub enum Constant<T> {
         type_: T,
     },
 
-    StringConcatenation {
+    /// A constant binary operation.
+    /// Most binops are not supported in constants yet, however we parse them
+    /// and produce an error during type analysis rather than during parsing so
+    /// we can get better error messages and language server code actions.
+    BinaryOperator {
         location: SrcSpan,
+        operator_start: u32,
+        operator: BinOp,
         left: Box<Self>,
         right: Box<Self>,
+        type_: T,
     },
 
     /// A placeholder constant used to allow module analysis to continue
@@ -112,15 +119,43 @@ pub enum Constant<T> {
     },
 }
 
+impl<T> Constant<T> {
+    pub fn bin_op_precedence(&self) -> u8 {
+        match self {
+            Self::BinaryOperator { operator, .. } => operator.precedence(),
+            Self::Int { .. }
+            | Self::Float { .. }
+            | Self::String { .. }
+            | Self::Var { .. }
+            | Self::List { .. }
+            | Self::Tuple { .. }
+            | Self::Todo { .. }
+            | Self::BitArray { .. }
+            | Self::Invalid { .. }
+            | Self::Record { .. }
+            | Self::RecordUpdate { .. } => u8::MAX,
+        }
+    }
+
+    pub fn bin_op_name(&self) -> Option<BinOp> {
+        if let Self::BinaryOperator { operator, .. } = self {
+            Some(*operator)
+        } else {
+            None
+        }
+    }
+}
+
 impl TypedConstant {
     pub fn type_(&self) -> Arc<Type> {
         match self {
             Constant::Int { .. } => type_::int(),
             Constant::Float { .. } => type_::float(),
-            Constant::String { .. } | Constant::StringConcatenation { .. } => type_::string(),
+            Constant::String { .. } => type_::string(),
             Constant::BitArray { .. } => type_::bit_array(),
 
             Constant::List { type_, .. }
+            | Constant::BinaryOperator { type_, .. }
             | Constant::Tuple { type_, .. }
             | Constant::Record { type_, .. }
             | Constant::RecordUpdate { type_, .. }
@@ -200,7 +235,7 @@ impl TypedConstant {
                 .iter()
                 .find_map(|segment| segment.find_node(byte_index))
                 .unwrap_or(Located::Constant(self)),
-            Constant::StringConcatenation { left, right, .. } => left
+            Constant::BinaryOperator { left, right, .. } => left
                 .find_node(byte_index)
                 .or_else(|| right.find_node(byte_index))
                 .unwrap_or(Located::Constant(self)),
@@ -216,7 +251,7 @@ impl TypedConstant {
             | Constant::List { .. }
             | Constant::BitArray { .. }
             | Constant::Todo { .. }
-            | Constant::StringConcatenation { .. }
+            | Constant::BinaryOperator { .. }
             | Constant::Invalid { .. } => None,
             Constant::Record {
                 record_constructor: value_constructor,
@@ -283,7 +318,7 @@ impl TypedConstant {
                 })
                 .fold(im::hashset![], im::HashSet::union),
 
-            Constant::StringConcatenation { left, right, .. } => left
+            Constant::BinaryOperator { left, right, .. } => left
                 .referenced_variables()
                 .union(right.referenced_variables()),
         }
@@ -448,14 +483,24 @@ impl TypedConstant {
             (Constant::Var { .. }, _) => false,
 
             (
-                Constant::StringConcatenation { left, right, .. },
-                Constant::StringConcatenation {
-                    left: other_left,
-                    right: other_right,
+                Constant::BinaryOperator {
+                    left,
+                    right,
+                    operator,
                     ..
                 },
-            ) => left.syntactically_eq(other_left) && right.syntactically_eq(other_right),
-            (Constant::StringConcatenation { .. }, _) => false,
+                Constant::BinaryOperator {
+                    left: other_left,
+                    right: other_right,
+                    operator: other_operator,
+                    ..
+                },
+            ) => {
+                operator == other_operator
+                    && left.syntactically_eq(other_left)
+                    && right.syntactically_eq(other_right)
+            }
+            (Constant::BinaryOperator { .. }, _) => false,
 
             (Constant::Invalid { .. }, _) => false,
         }
@@ -499,7 +544,7 @@ impl TypedConstant {
             | Constant::Record { .. }
             | Constant::RecordUpdate { .. }
             | Constant::BitArray { .. }
-            | Constant::StringConcatenation { .. }
+            | Constant::BinaryOperator { .. }
             | Constant::Var { .. }
             | Constant::Todo { .. }
             | Constant::Invalid { .. } => None,
@@ -553,7 +598,7 @@ impl<A> Constant<A> {
             | Constant::Var { location, .. }
             | Constant::Invalid { location, .. }
             | Constant::Todo { location, .. }
-            | Constant::StringConcatenation { location, .. } => *location,
+            | Constant::BinaryOperator { location, .. } => *location,
         }
     }
 
@@ -571,7 +616,7 @@ impl<A> Constant<A> {
             | Constant::Record { .. }
             | Constant::RecordUpdate { .. }
             | Constant::BitArray { .. }
-            | Constant::StringConcatenation { .. }
+            | Constant::BinaryOperator { .. }
             | Constant::Invalid { .. } => false,
         }
     }

--- a/compiler-core/src/ast/visit.rs
+++ b/compiler-core/src/ast/visit.rs
@@ -807,13 +807,24 @@ pub trait Visit<'ast> {
         visit_typed_constant_var(self, location, module, name, constructor, type_);
     }
 
-    fn visit_typed_constant_string_concatenation(
+    fn visit_typed_constant_binary_operator(
         &mut self,
         location: &'ast SrcSpan,
+        operator_start: &'ast u32,
+        operator: &'ast BinOp,
         left: &'ast TypedConstant,
         right: &'ast TypedConstant,
+        type_: &'ast Arc<Type>,
     ) {
-        visit_typed_constant_string_concatenation(self, location, left, right);
+        visit_typed_constant_binary_operator(
+            self,
+            location,
+            operator_start,
+            operator,
+            left,
+            right,
+            type_,
+        );
     }
 
     fn visit_typed_constant_invalid(
@@ -835,11 +846,14 @@ fn visit_typed_constant_invalid<'a, V: Visit<'a> + ?Sized>(
     // No further traversal needed for constant invalid expressions
 }
 
-fn visit_typed_constant_string_concatenation<'a, V: Visit<'a> + ?Sized>(
+fn visit_typed_constant_binary_operator<'a, V: Visit<'a> + ?Sized>(
     v: &mut V,
     _location: &'a SrcSpan,
+    _operator_start: &'a u32,
+    _operator: &'a BinOp,
     left: &'a TypedConstant,
     right: &'a TypedConstant,
+    _type: &'a Arc<Type>,
 ) {
     v.visit_typed_constant(left);
     v.visit_typed_constant(right);
@@ -1221,11 +1235,21 @@ pub fn visit_typed_constant<'a, V: Visit<'a> + ?Sized>(v: &mut V, constant: &'a 
             constructor,
             type_,
         } => v.visit_typed_constant_var(location, module, name, constructor, type_),
-        super::Constant::StringConcatenation {
+        super::Constant::BinaryOperator {
             location,
+            operator_start,
+            operator,
             left,
             right,
-        } => v.visit_typed_constant_string_concatenation(location, left, right),
+            type_,
+        } => v.visit_typed_constant_binary_operator(
+            location,
+            operator_start,
+            operator,
+            left,
+            right,
+            type_,
+        ),
         super::Constant::Invalid {
             location,
             type_,

--- a/compiler-core/src/ast_folder.rs
+++ b/compiler-core/src/ast_folder.rs
@@ -1038,11 +1038,16 @@ pub trait UntypedConstantFolder {
                 type_: (),
             } => self.fold_constant_var(location, module, name),
 
-            Constant::StringConcatenation {
+            Constant::BinaryOperator {
                 location,
+                operator_start,
                 left,
                 right,
-            } => self.fold_constant_string_concatenation(location, left, right),
+                operator,
+                type_: (),
+            } => {
+                self.fold_constant_binary_operator(location, operator_start, operator, left, right)
+            }
 
             Constant::Invalid {
                 location,
@@ -1184,16 +1189,21 @@ pub trait UntypedConstantFolder {
         }
     }
 
-    fn fold_constant_string_concatenation(
+    fn fold_constant_binary_operator(
         &mut self,
         location: SrcSpan,
+        operator_start: u32,
+        operator: BinOp,
         left: Box<UntypedConstant>,
         right: Box<UntypedConstant>,
     ) -> UntypedConstant {
-        Constant::StringConcatenation {
+        Constant::BinaryOperator {
             location,
+            operator_start,
+            operator,
             left,
             right,
+            type_: (),
         }
     }
 
@@ -1315,17 +1325,23 @@ pub trait UntypedConstantFolder {
                 Constant::BitArray { location, segments }
             }
 
-            Constant::StringConcatenation {
+            Constant::BinaryOperator {
                 location,
+                operator_start,
                 left,
                 right,
+                operator,
+                type_: (),
             } => {
                 let left = Box::new(self.fold_constant(*left));
                 let right = Box::new(self.fold_constant(*right));
-                Constant::StringConcatenation {
+                Constant::BinaryOperator {
                     location,
+                    operator_start,
+                    operator,
                     left,
                     right,
+                    type_: (),
                 }
             }
         }

--- a/compiler-core/src/call_graph.rs
+++ b/compiler-core/src/call_graph.rs
@@ -516,7 +516,7 @@ impl<'a> CallGraphBuilder<'a> {
                 }
             }
 
-            Constant::StringConcatenation { left, right, .. } => {
+            Constant::BinaryOperator { left, right, .. } => {
                 self.constant(left);
                 self.constant(right);
             }

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -2354,9 +2354,38 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
                 }
             }
 
-            Constant::StringConcatenation { left, right, .. } => {
-                self.constant_string_concatenate(builder, left, right);
-            }
+            Constant::BinaryOperator {
+                left,
+                right,
+                operator,
+                ..
+            } => match operator {
+                BinOp::Concatenate => self.constant_string_concatenate(builder, left, right),
+
+                BinOp::And
+                | BinOp::Or
+                | BinOp::Eq
+                | BinOp::NotEq
+                | BinOp::LtInt
+                | BinOp::LtEqInt
+                | BinOp::LtFloat
+                | BinOp::LtEqFloat
+                | BinOp::GtEqInt
+                | BinOp::GtInt
+                | BinOp::GtEqFloat
+                | BinOp::GtFloat
+                | BinOp::AddInt
+                | BinOp::AddFloat
+                | BinOp::SubInt
+                | BinOp::SubFloat
+                | BinOp::MultInt
+                | BinOp::MultFloat
+                | BinOp::DivInt
+                | BinOp::DivFloat
+                | BinOp::RemainderInt => {
+                    unreachable!("invalid constant binop made it to code generation")
+                }
+            },
 
             Constant::RecordUpdate { .. } => {
                 panic!("record updates should not reach code generation")
@@ -2435,7 +2464,12 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
                 // `<<<<~"a", ~"b">>/binary, ~"c">>`.
                 // If we find a string concatenation we push its separate items
                 // to be printed next!
-                Constant::StringConcatenation { left, right, .. } => {
+                Constant::BinaryOperator {
+                    left,
+                    right,
+                    operator: BinOp::Concatenate,
+                    ..
+                } => {
                     items.push_front(right);
                     items.push_front(left);
                     continue;
@@ -2469,6 +2503,7 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
                 | Constant::BitArray { .. }
                 | Constant::Var { .. }
                 | Constant::Invalid { .. }
+                | Constant::BinaryOperator { .. }
                 | Constant::Todo { .. } => (),
             }
 
@@ -3432,7 +3467,7 @@ fn constant_produces_literal_string(constant: &Constant<Arc<Type>>) -> bool {
         | Constant::Record { .. }
         | Constant::RecordUpdate { .. }
         | Constant::BitArray { .. }
-        | Constant::StringConcatenation { .. }
+        | Constant::BinaryOperator { .. }
         | Constant::Invalid { .. }
         | Constant::Todo { .. }
         | Constant::Var { .. } => false,
@@ -4118,7 +4153,7 @@ fn find_referenced_private_functions(
             .flatten()
             .for_each(|argument| find_referenced_private_functions(&argument.value, already_found)),
 
-        TypedConstant::StringConcatenation { left, right, .. } => {
+        TypedConstant::BinaryOperator { left, right, .. } => {
             find_referenced_private_functions(left, already_found);
             find_referenced_private_functions(right, already_found);
         }

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -5084,6 +5084,24 @@ Be sure to finish it before running your program.",
                 extra_labels: vec![],
             }),
         },
+        TypeError::InvalidConstantBinaryOperator {
+            operator_start,
+            operator,
+        } => Diagnostic {
+            title: "Unsupported operator in constant expression".into(),
+            text: wrap("This operator is currently not supported in constants."),
+            hint: None,
+            level: Level::Error,
+            location: Some(Location {
+                label: Label {
+                    text: None,
+                    span: SrcSpan::new(*operator_start, operator_start + operator.size()),
+                },
+                path: path.clone(),
+                src: src.clone(),
+                extra_labels: vec![],
+            }),
+        },
     })
 }
 

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -2848,11 +2848,42 @@ impl<'module, 'a, 'doc> Generator<'module, 'a, 'doc> {
                 }
             }
 
-            Constant::StringConcatenation { left, right, .. } => {
-                let left = self.constant_expression(arena, context, left);
-                let right = self.constant_expression(arena, context, right);
-                docvec![arena, left, SPACE_PLUS_SPACE_DOCUMENT, right]
-            }
+            Constant::BinaryOperator {
+                left,
+                right,
+                operator,
+                ..
+            } => match operator {
+                BinOp::And
+                | BinOp::Or
+                | BinOp::Eq
+                | BinOp::NotEq
+                | BinOp::LtInt
+                | BinOp::LtEqInt
+                | BinOp::LtFloat
+                | BinOp::LtEqFloat
+                | BinOp::GtEqInt
+                | BinOp::GtInt
+                | BinOp::GtEqFloat
+                | BinOp::GtFloat
+                | BinOp::AddInt
+                | BinOp::AddFloat
+                | BinOp::SubInt
+                | BinOp::SubFloat
+                | BinOp::MultInt
+                | BinOp::MultFloat
+                | BinOp::DivInt
+                | BinOp::DivFloat
+                | BinOp::RemainderInt => {
+                    unreachable!("invalid constant operator made it to code generation")
+                }
+
+                BinOp::Concatenate => {
+                    let left = self.constant_expression(arena, context, left);
+                    let right = self.constant_expression(arena, context, right);
+                    docvec![arena, left, SPACE_PLUS_SPACE_DOCUMENT, right]
+                }
+            },
 
             Constant::RecordUpdate { .. } => {
                 panic!("record updates should not reach code generation")
@@ -3388,7 +3419,7 @@ impl<'module, 'a, 'doc> Generator<'module, 'a, 'doc> {
             | Constant::String { .. }
             | Constant::List { .. }
             | Constant::RecordUpdate { .. }
-            | Constant::StringConcatenation { .. }
+            | Constant::BinaryOperator { .. }
             | Constant::Todo { .. }
             | Constant::Invalid { .. } => {
                 self.constant_expression(arena, Context::Guard, expression)

--- a/compiler-core/src/metadata.rs
+++ b/compiler-core/src/metadata.rs
@@ -426,12 +426,18 @@ impl RemapIds {
                     .map(|constructor| Box::new(self.value_constructor(*constructor))),
                 type_: self.type_(type_),
             },
-            Constant::StringConcatenation {
+            Constant::BinaryOperator {
                 location,
+                operator_start,
                 left,
                 right,
-            } => Constant::StringConcatenation {
+                operator,
+                type_,
+            } => Constant::BinaryOperator {
                 location,
+                operator_start,
+                operator,
+                type_,
                 left: Box::new(self.constant(*left)),
                 right: Box::new(self.constant(*right)),
             },

--- a/compiler-core/src/parse.rs
+++ b/compiler-core/src/parse.rs
@@ -1945,7 +1945,7 @@ where
 
             t0 => {
                 self.token0 = t0;
-                match self.parse_const_value()? {
+                match self.parse_const_value_unit()? {
                     Some(const_val) => {
                         // Constant
                         Ok(Some(ClauseGuard::Constant(const_val)))
@@ -3328,11 +3328,54 @@ where
     //   [1,2,3]
     //   wibble <> "wobble"
     fn parse_const_value(&mut self) -> Result<Option<UntypedConstant>, ParseError> {
-        let constant_result = self.parse_const_value_unit();
-        match constant_result {
-            Ok(Some(constant)) => self.parse_const_maybe_concatenation(constant),
-            _ => constant_result,
+        // uses the simple operator parser algorithm
+        let mut opstack = vec![];
+        let mut estack = vec![];
+        let mut last_op_start = 0;
+        let mut last_op_end = 0;
+
+        loop {
+            match self.parse_const_value_unit()? {
+                Some(unit) => estack.push(unit),
+                _ if estack.is_empty() => return Ok(None),
+                _ => {
+                    return parse_error(
+                        ParseErrorType::OpNakedRight,
+                        SrcSpan {
+                            start: last_op_start,
+                            end: last_op_end,
+                        },
+                    );
+                }
+            }
+
+            let Some((operator_start, operator, operator_end)) = self.token0.take() else {
+                break;
+            };
+
+            let Some(precedence) = precedence(&operator) else {
+                self.token0 = Some((operator_start, operator, operator_end));
+                break;
+            };
+
+            // Is Op
+            self.advance();
+            last_op_start = operator_start;
+            last_op_end = operator_end;
+            let _ = handle_operator(
+                Some(((operator_start, operator, operator_end), precedence)),
+                &mut opstack,
+                &mut estack,
+                &do_reduce_constant,
+            );
         }
+
+        Ok(handle_operator(
+            None,
+            &mut opstack,
+            &mut estack,
+            &do_reduce_constant,
+        ))
     }
 
     fn parse_const_value_unit(&mut self) -> Result<Option<UntypedConstant>, ParseError> {
@@ -3591,39 +3634,6 @@ where
             t0 => {
                 self.token0 = t0;
                 Ok(None)
-            }
-        }
-    }
-
-    fn parse_const_maybe_concatenation(
-        &mut self,
-        left: UntypedConstant,
-    ) -> Result<Option<UntypedConstant>, ParseError> {
-        match self.token0.take() {
-            Some((op_start, Token::Concatenate, op_end)) => {
-                self.advance();
-
-                match self.parse_const_value() {
-                    Ok(Some(right_constant_value)) => Ok(Some(Constant::StringConcatenation {
-                        location: SrcSpan {
-                            start: left.location().start,
-                            end: right_constant_value.location().end,
-                        },
-                        left: Box::new(left),
-                        right: Box::new(right_constant_value),
-                    })),
-                    _ => parse_error(
-                        ParseErrorType::OpNakedRight,
-                        SrcSpan {
-                            start: op_start,
-                            end: op_end,
-                        },
-                    ),
-                }
-            }
-            t0 => {
-                self.token0 = t0;
-                Ok(Some(left))
             }
         }
     }
@@ -5032,6 +5042,17 @@ fn do_reduce_clause_guard(operator: Spanned, estack: &mut Vec<UntypedClauseGuard
     }
 }
 
+/// Simple-Precedence-Parser, perform reduction for clause guard
+fn do_reduce_constant(op: Spanned, estack: &mut Vec<UntypedConstant>) {
+    match (estack.pop(), estack.pop()) {
+        (Some(er), Some(el)) => {
+            let new_e = constant_binop_reduction(op, el, er);
+            estack.push(new_e);
+        }
+        _ => panic!("Tried to reduce without 2 guards"),
+    }
+}
+
 /// Simple-Precedence-Parser, perform reduction for bit array size expressions
 fn reduce_bit_array_size((_, token, _): Spanned, experession_stack: &mut Vec<BitArraySize<()>>) {
     let operator = token_to_bit_array_size_operator(&token)
@@ -5103,6 +5124,28 @@ fn clause_guard_reduction(
         operator_start: start,
         left,
         right,
+    }
+}
+
+fn constant_binop_reduction(
+    (operator_start, operator_token, _end): Spanned,
+    left: UntypedConstant,
+    right: UntypedConstant,
+) -> UntypedConstant {
+    let location = SrcSpan {
+        start: left.location().start,
+        end: right.location().end,
+    };
+    let left = Box::new(left);
+    let right = Box::new(right);
+    let operator = token_to_binop(&operator_token).expect("Token could not be converted to binop.");
+    UntypedConstant::BinaryOperator {
+        location,
+        operator,
+        operator_start,
+        left,
+        right,
+        type_: (),
     }
 }
 

--- a/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_string_concat.snap
+++ b/compiler-core/src/parse/snapshots/gleam_core__parse__tests__const_string_concat.snap
@@ -58,11 +58,13 @@ Parsed {
                             end: 35,
                         },
                         annotation: None,
-                        value: StringConcatenation {
+                        value: BinaryOperator {
                             location: SrcSpan {
                                 start: 38,
                                 end: 51,
                             },
+                            operator_start: 43,
+                            operator: Concatenate,
                             left: Var {
                                 location: SrcSpan {
                                     start: 38,
@@ -80,6 +82,7 @@ Parsed {
                                 },
                                 value: "bee",
                             },
+                            type_: (),
                         },
                         type_: (),
                         deprecation: NotDeprecated,

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -714,6 +714,17 @@ pub enum Error {
     TodoConstant {
         location: SrcSpan,
     },
+    /// This happens when we use an invalid binary operator in a constant.
+    /// For example as of Gleam 1.18 float addition is not supported:
+    ///
+    /// ```gleam
+    /// pub const wibble = 1.1 +. 1.3
+    /// //                     ^^ Error!
+    /// ```
+    InvalidConstantBinaryOperator {
+        operator_start: u32,
+        operator: BinOp,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1405,6 +1416,7 @@ impl Error {
             Error::UnknownLabels { unknown, .. } => {
                 unknown.iter().map(|(_, s)| s.start).min().unwrap_or(0)
             }
+            Error::InvalidConstantBinaryOperator { operator_start, .. } => *operator_start,
             Error::ReservedModuleName { .. } => 0,
             Error::KeywordInModuleName { .. } => 0,
         }

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -1723,7 +1723,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                         | Constant::RecordUpdate { .. }
                         | Constant::BitArray { .. }
                         | Constant::Var { .. }
-                        | Constant::StringConcatenation { .. }
+                        | Constant::BinaryOperator { .. }
                         | Constant::Invalid { .. } => (),
                     }
                 }
@@ -4058,7 +4058,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                     | Constant::RecordUpdate { .. }
                     | Constant::BitArray { .. }
                     | Constant::Var { .. }
-                    | Constant::StringConcatenation { .. }
+                    | Constant::BinaryOperator { .. }
                     | Constant::Todo { .. }
                     | Constant::Invalid { .. } => typed_record,
                 };
@@ -4295,37 +4295,69 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 }
             }
 
-            Constant::StringConcatenation {
+            Constant::BinaryOperator {
                 location,
                 left,
                 right,
-            } => {
-                self.track_feature_usage(FeatureKind::ConstantStringConcatenation, location);
-                let left = self.infer_const(&None, *left);
+                operator,
+                operator_start,
+                type_: (),
+            } => match operator {
+                BinOp::And
+                | BinOp::Or
+                | BinOp::Eq
+                | BinOp::NotEq
+                | BinOp::LtInt
+                | BinOp::LtEqInt
+                | BinOp::LtFloat
+                | BinOp::LtEqFloat
+                | BinOp::GtEqInt
+                | BinOp::GtInt
+                | BinOp::GtEqFloat
+                | BinOp::GtFloat
+                | BinOp::AddInt
+                | BinOp::AddFloat
+                | BinOp::SubInt
+                | BinOp::SubFloat
+                | BinOp::MultInt
+                | BinOp::MultFloat
+                | BinOp::DivInt
+                | BinOp::DivFloat
+                | BinOp::RemainderInt => {
+                    // These operators are not currently allowed in constants.
+                    // We keep inferring the left and right values to catch
+                    // other invalid usages of this kind but we don't try and
+                    // type check those against some expected type!
+                    let left = self.infer_const_value(*left);
+                    let right = self.infer_const_value(*right);
+                    self.problems.error(Error::InvalidConstantBinaryOperator {
+                        operator_start,
+                        operator,
+                    });
 
-                if let Err(error) = unify(string(), left.type_()) {
-                    self.problems.error(
-                        error
-                            .operator_situation(BinOp::Concatenate)
-                            .into_error(left.location()),
-                    );
+                    Constant::BinaryOperator {
+                        location,
+                        operator_start,
+                        operator,
+                        left: Box::new(left),
+                        right: Box::new(right),
+                        // We use an unbound type so we don't get type errors
+                        // for this invalid binary operator. We only want an
+                        // error message saying "this is not supported", other
+                        // type errors like "Expected String, got Int" wouldn't
+                        // be all that useful.
+                        type_: self.new_unbound_var(),
+                    }
                 }
 
-                let right = self.infer_const(&None, *right);
-                if let Err(error) = unify(string(), right.type_()) {
-                    self.problems.error(
-                        error
-                            .operator_situation(BinOp::Concatenate)
-                            .into_error(right.location()),
-                    );
-                }
-
-                Constant::StringConcatenation {
+                BinOp::Concatenate => self.infer_constant_string_concatenation(
                     location,
-                    left: Box::new(left),
-                    right: Box::new(right),
-                }
-            }
+                    operator_start,
+                    left,
+                    right,
+                    operator,
+                ),
+            },
 
             Constant::Todo {
                 location, message, ..
@@ -4356,6 +4388,44 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         }
     }
 
+    fn infer_constant_string_concatenation(
+        &mut self,
+        location: SrcSpan,
+        operator_start: u32,
+        left: Box<UntypedConstant>,
+        right: Box<UntypedConstant>,
+        operator: BinOp,
+    ) -> TypedConstant {
+        self.track_feature_usage(FeatureKind::ConstantStringConcatenation, location);
+        let left = self.infer_const(&None, *left);
+
+        if let Err(error) = unify(string(), left.type_()) {
+            self.problems.error(
+                error
+                    .operator_situation(BinOp::Concatenate)
+                    .into_error(left.location()),
+            );
+        }
+
+        let right = self.infer_const(&None, *right);
+        if let Err(error) = unify(string(), right.type_()) {
+            self.problems.error(
+                error
+                    .operator_situation(BinOp::Concatenate)
+                    .into_error(right.location()),
+            );
+        }
+
+        Constant::BinaryOperator {
+            location,
+            operator_start,
+            operator,
+            type_: string(),
+            left: Box::new(left),
+            right: Box::new(right),
+        }
+    }
+
     fn infer_constant_record(
         &mut self,
         module: Option<(EcoString, SrcSpan)>,
@@ -4363,7 +4433,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         arguments_start_position: u32,
         name: EcoString,
         arguments: Option<Vec<CallArg<UntypedConstant>>>,
-    ) -> Constant<Arc<Type>> {
+    ) -> TypedConstant {
         // We start by inferring the value constructor. If we can't do that we
         // immediately fail and return an invalid node.
         // TODO: in future we might want to make this more fault tolerant and
@@ -5572,7 +5642,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             | Constant::Record { .. }
             | Constant::RecordUpdate { .. }
             | Constant::BitArray { .. }
-            | Constant::StringConcatenation { .. }
+            | Constant::BinaryOperator { .. }
             | Constant::Todo { .. }
             | Constant::Invalid { .. } => (),
         }
@@ -5718,8 +5788,7 @@ fn invalid_with_annotated_type(constant: TypedConstant, new_type: Arc<Type>) -> 
         Constant::Int { location, .. }
         | Constant::Float { location, .. }
         | Constant::String { location, .. }
-        | Constant::BitArray { location, .. }
-        | Constant::StringConcatenation { location, .. } => TypedConstant::Invalid {
+        | Constant::BitArray { location, .. } => TypedConstant::Invalid {
             location,
             type_: new_type,
             extra_information: None,
@@ -5733,6 +5802,22 @@ fn invalid_with_annotated_type(constant: TypedConstant, new_type: Arc<Type>) -> 
             location,
             type_: new_type,
             message,
+        },
+
+        Constant::BinaryOperator {
+            location,
+            operator_start,
+            operator,
+            left,
+            right,
+            type_: _,
+        } => Constant::BinaryOperator {
+            location,
+            operator_start,
+            operator,
+            left,
+            right,
+            type_: new_type,
         },
 
         // In all other cases we don't want to lose information on

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -4353,8 +4353,8 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
                 BinOp::Concatenate => self.infer_constant_string_concatenation(
                     location,
                     operator_start,
-                    left,
-                    right,
+                    *left,
+                    *right,
                     operator,
                 ),
             },
@@ -4392,12 +4392,12 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
         &mut self,
         location: SrcSpan,
         operator_start: u32,
-        left: Box<UntypedConstant>,
-        right: Box<UntypedConstant>,
+        left: UntypedConstant,
+        right: UntypedConstant,
         operator: BinOp,
     ) -> TypedConstant {
         self.track_feature_usage(FeatureKind::ConstantStringConcatenation, location);
-        let left = self.infer_const(&None, *left);
+        let left = self.infer_const(&None, left);
 
         if let Err(error) = unify(string(), left.type_()) {
             self.problems.error(
@@ -4407,7 +4407,7 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             );
         }
 
-        let right = self.infer_const(&None, *right);
+        let right = self.infer_const(&None, right);
         if let Err(error) = unify(string(), right.type_()) {
             self.problems.error(
                 error

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -4369,3 +4369,40 @@ const a = A()
 "
     );
 }
+
+#[test]
+fn constant_unsupported_binop() {
+    assert_module_error!("const a = 1 > 2");
+}
+
+#[test]
+fn constant_unsupported_binop_2() {
+    assert_module_error!("const a = 1 <=. 2");
+}
+
+#[test]
+fn multiple_constant_unsupported_binops() {
+    assert_module_error!(
+        "const a = [
+  1 + 2,
+  1 - 2,
+  \"this is ok\" <> \"no error here!\",
+  1 * 2,
+  1 >=. 3.0,
+]"
+    );
+}
+
+#[test]
+fn invalid_operator_in_constants_does_not_stop_analysis() {
+    assert_module_error!(
+        "
+// We will see an error here
+const a = 1 + 2
+// And an error here!
+const b = 1 - 2
+// And an error here!
+const c = 1 - does_not_exist
+"
+    );
+}

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__constant_unsupported_binop.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__constant_unsupported_binop.snap
@@ -1,0 +1,15 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: const a = 1 > 2
+---
+----- SOURCE CODE
+const a = 1 > 2
+
+----- ERROR
+error: Unsupported operator in constant expression
+  ┌─ /src/one/two.gleam:1:13
+  │
+1 │ const a = 1 > 2
+  │             ^
+
+This operator is currently not supported in constants.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__constant_unsupported_binop_2.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__constant_unsupported_binop_2.snap
@@ -1,0 +1,15 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: const a = 1 <=. 2
+---
+----- SOURCE CODE
+const a = 1 <=. 2
+
+----- ERROR
+error: Unsupported operator in constant expression
+  ┌─ /src/one/two.gleam:1:13
+  │
+1 │ const a = 1 <=. 2
+  │             ^^^
+
+This operator is currently not supported in constants.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_operator_in_constants_does_not_stop_analysis.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__invalid_operator_in_constants_does_not_stop_analysis.snap
@@ -1,0 +1,46 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\n// We will see an error here\nconst a = 1 + 2\n// And an error here!\nconst b = 1 - 2\n// And an error here!\nconst c = 1 - does_not_exist\n"
+---
+----- SOURCE CODE
+
+// We will see an error here
+const a = 1 + 2
+// And an error here!
+const b = 1 - 2
+// And an error here!
+const c = 1 - does_not_exist
+
+
+----- ERROR
+error: Unsupported operator in constant expression
+  ┌─ /src/one/two.gleam:3:13
+  │
+3 │ const a = 1 + 2
+  │             ^
+
+This operator is currently not supported in constants.
+
+error: Unsupported operator in constant expression
+  ┌─ /src/one/two.gleam:5:13
+  │
+5 │ const b = 1 - 2
+  │             ^
+
+This operator is currently not supported in constants.
+
+error: Unsupported operator in constant expression
+  ┌─ /src/one/two.gleam:7:13
+  │
+7 │ const c = 1 - does_not_exist
+  │             ^
+
+This operator is currently not supported in constants.
+
+error: Unknown variable
+  ┌─ /src/one/two.gleam:7:15
+  │
+7 │ const c = 1 - does_not_exist
+  │               ^^^^^^^^^^^^^^
+
+The name `does_not_exist` is not in scope here.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__multiple_constant_unsupported_binops.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__multiple_constant_unsupported_binops.snap
@@ -1,0 +1,45 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "const a = [\n  1 + 2,\n  1 - 2,\n  \"this is ok\" <> \"no error here!\",\n  1 * 2,\n  1 >=. 3.0,\n]"
+---
+----- SOURCE CODE
+const a = [
+  1 + 2,
+  1 - 2,
+  "this is ok" <> "no error here!",
+  1 * 2,
+  1 >=. 3.0,
+]
+
+----- ERROR
+error: Unsupported operator in constant expression
+  ┌─ /src/one/two.gleam:2:5
+  │
+2 │   1 + 2,
+  │     ^
+
+This operator is currently not supported in constants.
+
+error: Unsupported operator in constant expression
+  ┌─ /src/one/two.gleam:3:5
+  │
+3 │   1 - 2,
+  │     ^
+
+This operator is currently not supported in constants.
+
+error: Unsupported operator in constant expression
+  ┌─ /src/one/two.gleam:5:5
+  │
+5 │   1 * 2,
+  │     ^
+
+This operator is currently not supported in constants.
+
+error: Unsupported operator in constant expression
+  ┌─ /src/one/two.gleam:6:5
+  │
+6 │   1 >=. 3.0,
+  │     ^^^
+
+This operator is currently not supported in constants.

--- a/format/src/lib.rs
+++ b/format/src/lib.rs
@@ -517,8 +517,38 @@ impl<'a, 'doc> Formatter<'a> {
                         .append(arena, COLON_SPACE_DOCUMENT)
                         .append(arena, self.type_ast(arena, type_)),
                 };
-                head.append(arena, SPACE_EQUAL_SPACE_DOCUMENT)
-                    .append(arena, self.const_expr(arena, value).group(arena))
+
+                let value = match value.as_ref() {
+                    UntypedConstant::List { .. }
+                    | UntypedConstant::Tuple { .. }
+                    | UntypedConstant::BitArray { .. } => {
+                        let expression_comments = self.pop_comments(value.location().start);
+                        let expression_doc = self.const_expr(arena, value);
+                        match printed_comments(arena, expression_comments, true) {
+                            Some(comments) => LINE_DOCUMENT
+                                .append(arena, comments)
+                                .append(arena, expression_doc)
+                                .nest(arena, INDENT),
+                            None => SPACE_DOCUMENT.append(arena, expression_doc),
+                        }
+                    }
+
+                    Constant::Int { .. }
+                    | Constant::Float { .. }
+                    | Constant::String { .. }
+                    | Constant::Record { .. }
+                    | Constant::RecordUpdate { .. }
+                    | Constant::Var { .. }
+                    | Constant::BinaryOperator { .. }
+                    | Constant::Invalid { .. }
+                    | Constant::Todo { .. } => BREAKABLE_SPACE_DOCUMENT
+                        .append(arena, self.const_expr(arena, value).group(arena))
+                        .nest(arena, INDENT),
+                }
+                .next_break_fits(arena, NextBreakFitsMode::Disabled)
+                .group(arena);
+
+                docvec![arena, head, SPACE_EQUAL_DOCUMENT, value]
             }
         }
     }
@@ -640,7 +670,13 @@ impl<'a, 'doc> Formatter<'a> {
                 right,
                 operator,
                 ..
-            } => self.constant_binary_operator(arena, &operator, left.as_ref(), right.as_ref()),
+            } => self.constant_binary_operator(
+                arena,
+                &operator,
+                left.as_ref(),
+                right.as_ref(),
+                false,
+            ),
 
             Constant::RecordUpdate {
                 module,
@@ -693,11 +729,16 @@ impl<'a, 'doc> Formatter<'a> {
             ItemsPacking::FitOnePerLine | ItemsPacking::BreakOnePerLine => COMMA_BREAK_DOCUMENT,
         };
 
+        let list_size = elements.len()
+            + match tail {
+                Some(_) => 1,
+                None => 0,
+            };
         let mut is_empty = true;
         let mut elements_doc = EMPTY_DOCUMENT;
         for element in elements.iter() {
             let empty_lines = self.pop_empty_lines(element.location().start);
-            let element_doc = self.const_expr(arena, element);
+            let element_doc = self.comma_separated_constant_item(arena, element, list_size);
 
             elements_doc = if is_empty {
                 is_empty = false;
@@ -792,31 +833,14 @@ impl<'a, 'doc> Formatter<'a> {
             };
         }
 
-        let arguments_docs = elements
-            .iter()
-            .map(|element| self.const_expr(arena, element));
-        let tuple_doc = OPEN_TUPLE_BREAK_DOCUMENT
-            .append(
-                arena,
-                arena
-                    .join(arguments_docs, COMMA_BREAK_DOCUMENT)
-                    .next_break_fits(arena, NextBreakFitsMode::Disabled),
-            )
-            .nest(arena, INDENT);
-
-        let comments = self.pop_comments(location.end);
-        match printed_comments(arena, comments, false) {
-            None => tuple_doc
-                .append(arena, TRAILING_COMMA_BREAK_DOCUMENT)
-                .append(arena, CLOSE_PAREN_DOCUMENT)
-                .group(arena),
-            Some(comments) => tuple_doc
-                .append(arena, TRAILING_COMMA_BREAK_DOCUMENT.nest(arena, INDENT))
-                .append(arena, comments.nest(arena, INDENT))
-                .append(arena, LINE_DOCUMENT)
-                .append(arena, CLOSE_PAREN_DOCUMENT)
-                .force_break(arena),
-        }
+        self.append_inlinable_wrapped_arguments(
+            arena,
+            HASHTAG_DOCUMENT,
+            elements,
+            location,
+            |constant| !constant.is_tuple() && is_constant_breakable_argument(constant),
+            |self_, constant| self_.comma_separated_constant_item(arena, constant, elements.len()),
+        )
     }
 
     fn documented_definition(
@@ -1802,7 +1826,7 @@ impl<'a, 'doc> Formatter<'a> {
         location: &SrcSpan,
     ) -> Document<'a, 'doc> {
         let constructor_doc = match module {
-            Some((m, _)) => m
+            Some((module, _)) => module
                 .to_doc(arena)
                 .append(arena, DOT_DOCUMENT)
                 .append(arena, name.as_str()),
@@ -1813,41 +1837,32 @@ impl<'a, 'doc> Formatter<'a> {
             .chain(arguments.iter().map(RecordUpdatePiece::Argument))
             .collect_vec();
 
-        let docs = pieces
-            .iter()
-            .map(|piece| match piece {
+        self.append_inlinable_wrapped_arguments(
+            arena,
+            constructor_doc,
+            &pieces,
+            location,
+            |argument| {
+                let expression = match argument {
+                    RecordUpdatePiece::Argument(argument) => &argument.value,
+                    RecordUpdatePiece::Record(record) => &record.base,
+                };
+                is_constant_breakable_argument(expression)
+            },
+            |this, argument| match argument {
                 RecordUpdatePiece::Argument(argument) => {
-                    let comments = self.pop_comments(argument.location.start);
-                    let doc = match argument {
-                        _ if argument.uses_label_shorthand() => argument
-                            .label
-                            .as_str()
-                            .to_doc(arena)
-                            .append(arena, COLON_DOCUMENT),
-                        _ => argument
-                            .label
-                            .as_str()
-                            .to_doc(arena)
-                            .append(arena, COLON_SPACE_DOCUMENT)
-                            .append(arena, self.const_expr(arena, &argument.value))
-                            .group(arena),
-                    };
-                    commented(arena, doc, comments)
+                    this.constant_record_update_argument(arena, argument)
                 }
                 RecordUpdatePiece::Record(record) => {
-                    let comments = self.pop_comments(record.location.start);
+                    let comments = this.pop_comments(record.location.start);
                     commented(
                         arena,
-                        DOT_DOT_DOCUMENT.append(arena, self.const_expr(arena, &record.base)),
+                        DOT_DOT_DOCUMENT.append(arena, this.const_expr(arena, &record.base)),
                         comments,
                     )
                 }
-            })
-            .collect_vec();
-
-        constructor_doc
-            .append(arena, self.wrap_arguments(arena, docs, location.end))
-            .group(arena)
+            },
+        )
     }
 
     pub fn bin_op(
@@ -1885,19 +1900,24 @@ impl<'a, 'doc> Formatter<'a> {
         name: &'a BinOp,
         left: &'a UntypedConstant,
         right: &'a UntypedConstant,
+        nest_steps: bool,
     ) -> Document<'a, 'doc> {
-        let left_side = self.constant_binary_operator_side(arena, name, left);
+        let left_side = self.constant_binary_operator_side(arena, name, left, nest_steps);
 
         let comments = self.pop_comments(right.location().start);
         let name_doc =
             BREAKABLE_SPACE_DOCUMENT.append(arena, commented(arena, binop(*name), comments));
 
-        let right_side = self.constant_binary_operator_side(arena, name, right);
+        let right_side = self.constant_binary_operator_side(arena, name, right, nest_steps);
 
         docvec![
             arena,
             left_side,
-            name_doc.nest(arena, INDENT),
+            if nest_steps {
+                name_doc.nest(arena, INDENT)
+            } else {
+                name_doc
+            },
             SPACE_DOCUMENT,
             right_side
         ]
@@ -1908,6 +1928,7 @@ impl<'a, 'doc> Formatter<'a> {
         arena: &'doc DocumentArena<'a, 'doc>,
         operator: &'a BinOp,
         side: &'a UntypedConstant,
+        nest_steps: bool,
     ) -> Document<'a, 'doc> {
         let side_doc = match side {
             UntypedConstant::String { value, .. } => self.bin_op_string(arena, value),
@@ -1916,7 +1937,7 @@ impl<'a, 'doc> Formatter<'a> {
                 left,
                 right,
                 ..
-            } => self.constant_binary_operator(arena, operator, left, right),
+            } => self.constant_binary_operator(arena, operator, left, right, nest_steps),
             UntypedConstant::Int { .. }
             | UntypedConstant::Float { .. }
             | UntypedConstant::Var { .. }
@@ -2430,6 +2451,42 @@ impl<'a, 'doc> Formatter<'a> {
                     .group(arena);
 
                 if argument.value.is_binop() || argument.value.is_pipeline() {
+                    commented(arena, doc, comments).nest(arena, INDENT)
+                } else {
+                    commented(arena, doc, comments)
+                }
+            }
+        }
+    }
+
+    fn constant_record_update_argument(
+        &mut self,
+        arena: &'doc DocumentArena<'a, 'doc>,
+        argument: &'a RecordUpdateArg<UntypedConstant>,
+    ) -> Document<'a, 'doc> {
+        let comments = self.pop_comments(argument.location.start);
+        match argument {
+            // Argument supplied with a label shorthand.
+            _ if argument.uses_label_shorthand() => commented(
+                arena,
+                argument
+                    .label
+                    .as_str()
+                    .to_doc(arena)
+                    .append(arena, COLON_DOCUMENT),
+                comments,
+            ),
+            // Labelled argument.
+            _ => {
+                let doc = argument
+                    .label
+                    .as_str()
+                    .to_doc(arena)
+                    .append(arena, COLON_SPACE_DOCUMENT)
+                    .append(arena, self.const_expr(arena, &argument.value))
+                    .group(arena);
+
+                if argument.value.is_binop() {
                     commented(arena, doc, comments).nest(arena, INDENT)
                 } else {
                     commented(arena, doc, comments)
@@ -2963,6 +3020,47 @@ impl<'a, 'doc> Formatter<'a> {
             | UntypedExpr::RecordUpdate { .. }
             | UntypedExpr::NegateBool { .. }
             | UntypedExpr::NegateInt { .. } => self.expr(arena, expression).group(arena),
+        }
+    }
+
+    /// Pretty prints an expression to be used in a comma separated list; for
+    /// example as a list item, a tuple item or as an argument of a function call.
+    fn comma_separated_constant_item(
+        &mut self,
+        arena: &'doc DocumentArena<'a, 'doc>,
+        constant: &'a UntypedConstant,
+        siblings: usize,
+    ) -> Document<'a, 'doc> {
+        // If there's more than one item in the comma separated list and there's a
+        // pipeline or long binary chain, we want to indent those to make it
+        // easier to tell where one item ends and the other starts.
+        // Othewise we just print the expression as a normal expr.
+        match constant {
+            UntypedConstant::BinaryOperator {
+                operator,
+                left,
+                right,
+                ..
+            } if siblings > 1 => {
+                let comments = self.pop_comments(constant.location().start);
+                let doc = self
+                    .constant_binary_operator(arena, operator, left, right, true)
+                    .group(arena);
+                commented(arena, doc, comments)
+            }
+
+            UntypedConstant::Int { .. }
+            | UntypedConstant::Float { .. }
+            | UntypedConstant::String { .. }
+            | UntypedConstant::Tuple { .. }
+            | UntypedConstant::List { .. }
+            | UntypedConstant::Record { .. }
+            | UntypedConstant::RecordUpdate { .. }
+            | UntypedConstant::BitArray { .. }
+            | UntypedConstant::Var { .. }
+            | UntypedConstant::BinaryOperator { .. }
+            | UntypedConstant::Invalid { .. }
+            | UntypedConstant::Todo { .. } => self.const_expr(arena, constant).group(arena),
         }
     }
 
@@ -4118,6 +4216,22 @@ fn is_breakable_argument(expression: &UntypedExpr, arity: usize) -> bool {
         | UntypedExpr::RecordUpdate { .. }
         | UntypedExpr::NegateBool { .. }
         | UntypedExpr::NegateInt { .. } => false,
+    }
+}
+
+fn is_constant_breakable_argument(expression: &UntypedConstant) -> bool {
+    match expression {
+        Constant::Tuple { .. } | Constant::List { .. } | Constant::BitArray { .. } => true,
+
+        Constant::Int { .. }
+        | Constant::Float { .. }
+        | Constant::String { .. }
+        | Constant::Record { .. }
+        | Constant::RecordUpdate { .. }
+        | Constant::Var { .. }
+        | Constant::BinaryOperator { .. }
+        | Constant::Invalid { .. }
+        | Constant::Todo { .. } => false,
     }
 }
 

--- a/format/src/lib.rs
+++ b/format/src/lib.rs
@@ -523,10 +523,10 @@ impl<'a, 'doc> Formatter<'a> {
         }
     }
 
-    fn const_expr<A>(
+    fn const_expr(
         &mut self,
         arena: &'doc DocumentArena<'a, 'doc>,
-        value: &'a Constant<A>,
+        value: &'a UntypedConstant,
     ) -> Document<'a, 'doc> {
         let comments = self.pop_comments(value.location().start);
         let document = match value {
@@ -635,15 +635,12 @@ impl<'a, 'doc> Formatter<'a> {
                 ..
             } => docvec![arena, module, DOT_DOCUMENT, name],
 
-            Constant::StringConcatenation { left, right, .. } => self
-                .const_expr(arena, left)
-                .append(
-                    arena,
-                    BREAKABLE_SPACE_DOCUMENT.append(arena, CONCAT_DOCUMENT),
-                )
-                .nest(arena, INDENT)
-                .append(arena, SPACE_DOCUMENT)
-                .append(arena, self.const_expr(arena, right)),
+            Constant::BinaryOperator {
+                left,
+                right,
+                operator,
+                ..
+            } => self.constant_binary_operator(arena, &operator, left.as_ref(), right.as_ref()),
 
             Constant::RecordUpdate {
                 module,
@@ -659,12 +656,12 @@ impl<'a, 'doc> Formatter<'a> {
         commented(arena, document, comments)
     }
 
-    fn const_list<A>(
+    fn const_list(
         &mut self,
         arena: &'doc DocumentArena<'a, 'doc>,
-        elements: &'a [Constant<A>],
+        elements: &'a [UntypedConstant],
         location: &SrcSpan,
-        tail: &'a Option<Box<Constant<A>>>,
+        tail: &'a Option<Box<UntypedConstant>>,
     ) -> Document<'a, 'doc> {
         if elements.is_empty() {
             // We take all comments that come _before_ the end of the list,
@@ -770,10 +767,10 @@ impl<'a, 'doc> Formatter<'a> {
         }
     }
 
-    pub fn const_tuple<A>(
+    pub fn const_tuple(
         &mut self,
         arena: &'doc DocumentArena<'a, 'doc>,
-        elements: &'a [Constant<A>],
+        elements: &'a [UntypedConstant],
         location: &SrcSpan,
     ) -> Document<'a, 'doc> {
         if elements.is_empty() {
@@ -1795,13 +1792,13 @@ impl<'a, 'doc> Formatter<'a> {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn const_record_update<A>(
+    pub fn const_record_update(
         &mut self,
         arena: &'doc DocumentArena<'a, 'doc>,
         module: &Option<(EcoString, SrcSpan)>,
         name: &'a EcoString,
-        record: &'a RecordBeingUpdated<Constant<A>>,
-        arguments: &'a [RecordUpdateArg<Constant<A>>],
+        record: &'a RecordBeingUpdated<UntypedConstant>,
+        arguments: &'a [RecordUpdateArg<UntypedConstant>],
         location: &SrcSpan,
     ) -> Document<'a, 'doc> {
         let constructor_doc = match module {
@@ -1880,6 +1877,75 @@ impl<'a, 'doc> Formatter<'a> {
             )
             .append(arena, SPACE_DOCUMENT)
             .append(arena, right_side)
+    }
+
+    pub fn constant_binary_operator(
+        &mut self,
+        arena: &'doc DocumentArena<'a, 'doc>,
+        name: &'a BinOp,
+        left: &'a UntypedConstant,
+        right: &'a UntypedConstant,
+    ) -> Document<'a, 'doc> {
+        let left_side = self.constant_binary_operator_side(arena, name, left);
+
+        let comments = self.pop_comments(right.location().start);
+        let name_doc =
+            BREAKABLE_SPACE_DOCUMENT.append(arena, commented(arena, binop(*name), comments));
+
+        let right_side = self.constant_binary_operator_side(arena, name, right);
+
+        docvec![
+            arena,
+            left_side,
+            name_doc.nest(arena, INDENT),
+            SPACE_DOCUMENT,
+            right_side
+        ]
+    }
+
+    fn constant_binary_operator_side(
+        &mut self,
+        arena: &'doc DocumentArena<'a, 'doc>,
+        operator: &'a BinOp,
+        side: &'a UntypedConstant,
+    ) -> Document<'a, 'doc> {
+        let side_doc = match side {
+            UntypedConstant::String { value, .. } => self.bin_op_string(arena, value),
+            UntypedConstant::BinaryOperator {
+                operator,
+                left,
+                right,
+                ..
+            } => self.constant_binary_operator(arena, operator, left, right),
+            UntypedConstant::Int { .. }
+            | UntypedConstant::Float { .. }
+            | UntypedConstant::Var { .. }
+            | UntypedConstant::List { .. }
+            | UntypedConstant::Tuple { .. }
+            | UntypedConstant::Todo { .. }
+            | UntypedConstant::BitArray { .. }
+            | UntypedConstant::Invalid { .. }
+            | UntypedConstant::Record { .. }
+            | UntypedConstant::RecordUpdate { .. } => self.const_expr(arena, side),
+        };
+        match side.bin_op_name() {
+            // In case the other side is a binary operation as well and it can
+            // be grouped together with the current binary operation, the two
+            // docs are simply concatenated, so that they will end up in the
+            // same group and the formatter will try to keep those on a single
+            // line.
+            Some(side_name) if side_name.can_be_grouped_with(operator) => side_doc,
+            // In case the binary operations cannot be grouped together the
+            // other side is treated as a group on its own so that it can be
+            // broken independently of other pieces of the binary operations
+            // chain.
+            _ => self.operator_side(
+                arena,
+                side_doc.group(arena),
+                operator.precedence(),
+                side.bin_op_precedence(),
+            ),
+        }
     }
 
     fn bin_op_side(
@@ -3196,10 +3262,10 @@ impl<'a, 'doc> Formatter<'a> {
         }
     }
 
-    fn constant_call_arg<A>(
+    fn constant_call_arg(
         &mut self,
         arena: &'doc DocumentArena<'a, 'doc>,
-        argument: &'a CallArg<Constant<A>>,
+        argument: &'a CallArg<UntypedConstant>,
     ) -> Document<'a, 'doc> {
         self.format_call_arg(
             arena,
@@ -3759,11 +3825,11 @@ impl<'a, 'doc> Formatter<'a> {
         doc.group(arena)
     }
 
-    fn append_as_message_constant<A>(
+    fn append_as_message_constant(
         &mut self,
         arena: &'doc DocumentArena<'a, 'doc>,
         doc: Document<'a, 'doc>,
-        message: Option<&'a Constant<A>>,
+        message: Option<&'a UntypedConstant>,
     ) -> Document<'a, 'doc> {
         let Some(message) = message else { return doc };
 
@@ -4103,9 +4169,9 @@ fn pattern_call_arg_formatting(
     }
 }
 
-fn constant_call_arg_formatting<A>(
-    argument: &CallArg<Constant<A>>,
-) -> CallArgFormatting<'_, Constant<A>> {
+fn constant_call_arg_formatting(
+    argument: &CallArg<UntypedConstant>,
+) -> CallArgFormatting<'_, UntypedConstant> {
     match argument {
         // An argument supplied using label shorthand syntax.
         _ if argument.uses_label_shorthand() => CallArgFormatting::ShorthandLabelled(

--- a/format/src/lib.rs
+++ b/format/src/lib.rs
@@ -670,13 +670,9 @@ impl<'a, 'doc> Formatter<'a> {
                 right,
                 operator,
                 ..
-            } => self.constant_binary_operator(
-                arena,
-                &operator,
-                left.as_ref(),
-                right.as_ref(),
-                false,
-            ),
+            } => {
+                self.constant_binary_operator(arena, operator, left.as_ref(), right.as_ref(), false)
+            }
 
             Constant::RecordUpdate {
                 module,
@@ -3701,7 +3697,7 @@ impl<'a, 'doc> Formatter<'a> {
             Some(comment) => docvec![
                 arena,
                 TRAILING_COMMA_BREAK_DOCUMENT.nest(arena, INDENT),
-                comment,
+                comment.nest(arena, INDENT),
                 LINE_DOCUMENT,
                 CLOSE_PAREN_DOCUMENT
             ]

--- a/format/src/tests.rs
+++ b/format/src/tests.rs
@@ -5986,7 +5986,8 @@ fn const_long_concat_string() {
     assert_format_rewrite!(
         r#"const long_string = "some" <> " very" <> " long" <> " string" <> " indeed" <> " please" <> " break"
 "#,
-        r#"const long_string = "some"
+        r#"const long_string =
+  "some"
   <> " very"
   <> " long"
   <> " string"
@@ -6010,7 +6011,8 @@ fn const_concat_long_including_list() {
     assert_format_rewrite!(
         r#"const x = "some long string 1" <> "some long string 2" <> ["here is a list", "with several elements", "in order to make it be too long to fit on one line", "so we can see how it breaks", "onto multiple lines"] <> "and a last string"
 "#,
-        r#"const x = "some long string 1"
+        r#"const x =
+  "some long string 1"
   <> "some long string 2"
   <> [
     "here is a list",

--- a/format/src/tests/binary_operators.rs
+++ b/format/src/tests/binary_operators.rs
@@ -40,6 +40,24 @@ pub fn long_comparison_chain() {
 }
 
 #[test]
+pub fn long_constant_comparison_chain() {
+    assert_format!(
+        r#"pub const wibble =
+  trying_a_comparison > with_ints
+  && trying_other_comparisons < with_ints
+  || trying_other_comparisons <= with_ints
+  && trying_other_comparisons >= with_ints
+  || and_now_an_equality_check == with_a_const
+  && trying_other_comparisons >. with_floats
+  || trying_other_comparisons <. with_floats
+  && trying_other_comparisons <=. with_floats
+  || trying_other_comparisons >=. with_floats
+  && wibble <> wobble
+"#
+    );
+}
+
+#[test]
 pub fn long_chain_mixing_operators() {
     assert_format!(
         r#"pub fn main() {
@@ -56,6 +74,28 @@ pub fn long_chain_mixing_operators() {
   == variable *. variable /. variable -. variable +. variable
   || wibble *. wobble >=. 11
 }
+"#
+    );
+}
+
+#[test]
+pub fn long_constant_chain_mixing_operators() {
+    assert_format!(
+        r#"pub const wibble =
+  variable + variable - variable * variable / variable
+  == variable * variable / variable - variable + variable
+  || wibble * wobble > 11
+"#
+    );
+}
+
+#[test]
+pub fn long_constant_chain_mixing_operators_2() {
+    assert_format!(
+        r#"pub const wibble =
+  variable +. variable -. variable *. variable /. variable
+  == variable *. variable /. variable -. variable +. variable
+  || wibble *. wobble >=. 11
 "#
     );
 }
@@ -219,6 +259,19 @@ fn binop_inside_list_gets_nested() {
 }
 
 #[test]
+fn constant_binop_inside_list_gets_nested() {
+    assert_format!(
+        r#"pub const wibble = [
+  wibble,
+  a_variable_with_a_long_name
+    <> another_variable_with_a_long_name
+    <> yet_another_variable_with_a_long_name,
+]
+"#
+    );
+}
+
+#[test]
 fn binop_inside_list_is_not_nested_if_only_item() {
     assert_format!(
         r#"pub fn main() {
@@ -228,6 +281,18 @@ fn binop_inside_list_is_not_nested_if_only_item() {
     <> yet_another_variable_with_a_long_name,
   ]
 }
+"#
+    );
+}
+
+#[test]
+fn constant_binop_inside_list_is_not_nested_if_only_item() {
+    assert_format!(
+        r#"pub const wibble = [
+  a_variable_with_a_long_name
+  <> another_variable_with_a_long_name
+  <> yet_another_variable_with_a_long_name,
+]
 "#
     );
 }
@@ -248,6 +313,19 @@ fn binop_inside_tuple_gets_nested() {
 }
 
 #[test]
+fn constant_binop_inside_tuple_gets_nested() {
+    assert_format!(
+        r#"pub const wibble = #(
+  wibble,
+  a_variable_with_a_long_name
+    <> another_variable_with_a_long_name
+    <> yet_another_variable_with_a_long_name,
+)
+"#
+    );
+}
+
+#[test]
 fn binop_inside_tuple_is_not_nested_if_only_item() {
     assert_format!(
         r#"pub fn main() {
@@ -257,6 +335,18 @@ fn binop_inside_tuple_is_not_nested_if_only_item() {
     <> yet_another_variable_with_a_long_name,
   )
 }
+"#
+    );
+}
+
+#[test]
+fn constant_binop_inside_tuple_is_not_nested_if_only_item() {
+    assert_format!(
+        r#"pub const wibble = #(
+  a_variable_with_a_long_name
+  <> another_variable_with_a_long_name
+  <> yet_another_variable_with_a_long_name,
+)
 "#
     );
 }
@@ -273,6 +363,20 @@ fn binop_as_argument_in_variant_with_spread_gets_nested() {
       <> "another string",
   )
 }
+"#
+    );
+}
+
+#[test]
+fn constant_binop_as_argument_in_variant_with_spread_gets_nested() {
+    assert_format!(
+        r#"pub const wibble =
+  Wibble(
+    ..wibble,
+    label: string
+      <> "a long string that is making things go on multiple lines"
+      <> "another string",
+  )
 "#
     );
 }

--- a/format/src/tests/constant.rs
+++ b/format/src/tests/constant.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2025 The Gleam contributors
 
-use crate::assert_format;
+use crate::{assert_format, assert_format_rewrite};
 
 // https://github.com/gleam-lang/gleam/issues/5143
 #[test]
@@ -36,10 +36,11 @@ fn const_record_update_long() {
 
 pub const c = Counter(0)
 
-pub const c2 = Counter(
-  ..c,
-  loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong: 1,
-)
+pub const c2 =
+  Counter(
+    ..c,
+    loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong: 1,
+  )
 "#
     );
 }
@@ -111,8 +112,13 @@ fn constant_todo_message() {
 fn constant_todo_commented_message() {
     assert_format!(
         r#"pub const wibble = todo as
-  // some comment
-  "message"
+    // some comment
+    "message"
 "#
     );
+}
+
+#[test]
+fn constant_sum() {
+    assert_format_rewrite!("const wibble = 1 +   2", "const wibble = 1 + 2\n");
 }


### PR DESCRIPTION
This PR fixes #6050 

Also adding the BinaryOperator variant to constants I noticed there were some discrepancies with how we formatted constants compared to regular expressions. Probably some code was left behind as we updated expressions' formatting over time. I've updated it to make things consistent!

This should also make it pretty straightforward for Surya to take care of #1488 now!

- [X] The changes in this PR have been discussed beforehand in an issue
- [X] The issue for this PR has been linked
- [X] Tests have been added for new behaviour
- [X] The changelog has been updated for any user-facing changes
