### PR TITLE
fix: LSP panic on client disconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,10 @@
   types with a same-named import alias.
   ([Andrey Kozhev](https://github.com/ankddev))
 
+- Fixed a bug where the language server would crash if the client disconnected
+  unexpectedly.
+  ([Senthilnathan](https://github.com/ssenthilnathan3))
+
 - Fixed a bug where comments after the last item in a tuple, or after the last
   argument in a function call wouldn't be formatted properly.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -197,6 +197,12 @@ pub enum Error {
     #[error("{error}")]
     GitInitialization { error: String },
 
+    #[error("Failed to send LSP message: {error}")]
+    LspMessageSendFailed { error: String },
+
+    #[error("Failed to receive LSP message: {error}")]
+    LspMessageReceiveFailed { error: String },
+
     #[error("io operation failed")]
     StandardIo {
         action: StandardIoAction,
@@ -1950,6 +1956,42 @@ with `gleam hex authenticate`."
                 );
                 vec![Diagnostic {
                     title: "Failed to initialize git repository".into(),
+                    text,
+                    hint: None,
+                    level: Level::Error,
+                    location: None,
+                }]
+            }
+
+            Error::LspMessageSendFailed { error } => {
+                let text = wrap_format!(
+                    "An error occurred when the Gleam language server \
+attempted to send a message to the client:
+
+    {error}
+
+Is your editor still running and connected to the language server?"
+                );
+                vec![Diagnostic {
+                    title: "Failed to send LSP message".into(),
+                    text,
+                    hint: None,
+                    level: Level::Error,
+                    location: None,
+                }]
+            }
+
+            Error::LspMessageReceiveFailed { error } => {
+                let text = wrap_format!(
+                    "An error occurred when the Gleam language server \
+attempted to receive a message from the client:
+
+    {error}
+
+Is your editor still running and connected to the language server?"
+                );
+                vec![Diagnostic {
+                    title: "Failed to send LSP message".into(),
                     text,
                     hint: None,
                     level: Level::Error,

--- a/compiler-core/src/error/snapshots/gleam_core__error__tests__lsp_message_receive_failed.snap
+++ b/compiler-core/src/error/snapshots/gleam_core__error__tests__lsp_message_receive_failed.snap
@@ -1,0 +1,12 @@
+---
+source: compiler-core/src/error/tests.rs
+expression: error
+---
+error: Failed to send LSP message
+
+An error occurred when the Gleam language server attempted to receive a
+message from the client:
+
+    disconnected channel
+
+Is your editor still running and connected to the language server?

--- a/compiler-core/src/error/snapshots/gleam_core__error__tests__lsp_message_send_failed.snap
+++ b/compiler-core/src/error/snapshots/gleam_core__error__tests__lsp_message_send_failed.snap
@@ -1,0 +1,12 @@
+---
+source: compiler-core/src/error/tests.rs
+expression: error
+---
+error: Failed to send LSP message
+
+An error occurred when the Gleam language server attempted to send a
+message to the client:
+
+    sending on a disconnected channel
+
+Is your editor still running and connected to the language server?

--- a/compiler-core/src/error/tests.rs
+++ b/compiler-core/src/error/tests.rs
@@ -240,3 +240,21 @@ fn wrap_with_multibyte_char_at_width_boundary() {
     let wrapped = wrap(&input);
     assert_eq!(wrapped.replace('\n', ""), input);
 }
+
+#[test]
+fn lsp_message_send_failed() {
+    let error = Error::LspMessageSendFailed {
+        error: "sending on a disconnected channel".into(),
+    }
+    .pretty_string();
+    assert_snapshot!(error);
+}
+
+#[test]
+fn lsp_message_receive_failed() {
+    let error = Error::LspMessageReceiveFailed {
+        error: "disconnected channel".into(),
+    }
+    .pretty_string();
+    assert_snapshot!(error);
+}

--- a/language-server/src/messages.rs
+++ b/language-server/src/messages.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2024 The Gleam contributors
 
 use camino::Utf8PathBuf;
+use gleam_core::{Error, Result};
 use lsp::{DefinitionRequest, DidChangeWatchedFilesNotification, DidOpenTextDocumentNotification};
 use lsp_types::{
     self as lsp, CodeActionRequest, CompletionRequest, DidChangeTextDocumentNotification,
@@ -191,38 +192,53 @@ impl MessageBuffer {
         }
     }
 
-    pub fn receive(&mut self, conn: &lsp_server::Connection) -> Next {
+    pub fn receive(&mut self, conn: &lsp_server::Connection) -> Result<Next> {
         let pause = Duration::from_millis(100);
 
         // If the buffer is empty, wait indefinitely for the first message.
         // If the buffer is not empty, wait for a short time to see if more messages are
         // coming before processing the ones we have.
         let message = if self.messages.is_empty() {
-            Some(conn.receiver.recv().expect("Receiving LSP message"))
+            Some(
+                conn.receiver
+                    .recv()
+                    .map_err(|error| Error::LspMessageReceiveFailed {
+                        error: error.to_string(),
+                    })?,
+            )
         } else {
-            conn.receiver.recv_timeout(pause).ok()
+            match conn.receiver.recv_timeout(pause) {
+                Ok(message) => Some(message),
+                Err(error) if error.is_timeout() => None,
+                Err(error) => {
+                    return Err(Error::LspMessageReceiveFailed {
+                        error: error.to_string(),
+                    });
+                }
+            }
         };
 
-        // If have have not received a message then it means there is a pause in the
+        // If we have not received a message then it means there is a pause in the
         // messages from the client, implying the programmer has stopped typing. Process
         // the currently enqueued messages.
         let message = match message {
             Some(message) => message,
             None => {
-                // A compile please message it added in the instance of this
+                // A compile please message is added in the instance of this
                 // pause of activity so that the client gets feedback on the
                 // state of the code as it is now.
                 self.push_compile_please_message();
-                return Next::Handle(self.take_messages());
+                return Ok(Next::Handle(self.take_messages()));
             }
         };
 
-        match message {
-            lsp_server::Message::Request(r) if self.shutdown(conn, &r) => Next::Stop,
+        let next = match message {
+            lsp_server::Message::Request(r) if self.shutdown(conn, &r)? => Next::Stop,
             lsp_server::Message::Request(r) => self.request(r),
             lsp_server::Message::Response(r) => self.response(r),
             lsp_server::Message::Notification(n) => self.notification(n),
-        }
+        };
+        Ok(next)
     }
 
     fn request(&mut self, r: lsp_server::Request) -> Next {
@@ -269,8 +285,12 @@ impl MessageBuffer {
         &mut self,
         connection: &lsp_server::Connection,
         request: &lsp_server::Request,
-    ) -> bool {
-        connection.handle_shutdown(request).expect("LSP shutdown")
+    ) -> Result<bool> {
+        connection
+            .handle_shutdown(request)
+            .map_err(|error| Error::LspMessageReceiveFailed {
+                error: error.to_string(),
+            })
     }
 }
 

--- a/language-server/src/server.rs
+++ b/language-server/src/server.rs
@@ -61,7 +61,7 @@ where
         + Clone,
 {
     pub fn new(connection: &'a lsp_server::Connection, io: IO) -> Result<Self> {
-        let initialise_params = initialisation_handshake(connection);
+        let initialise_params = initialisation_handshake(connection)?;
         let reporter = ConnectionProgressReporter::new(connection, &initialise_params);
         let io = FileSystemProxy::new(io);
         let router = Router::new(reporter, io.clone());
@@ -76,16 +76,16 @@ where
     }
 
     pub fn run(&mut self) -> Result<()> {
-        self.start_watching_gleam_toml();
+        self.start_watching_gleam_toml()?;
         let mut buffer = MessageBuffer::new();
 
         loop {
-            match buffer.receive(*self.connection) {
+            match buffer.receive(*self.connection)? {
                 Next::Stop => break,
                 Next::MorePlease => (),
                 Next::Handle(messages) => {
                     for message in messages {
-                        self.handle_message(message);
+                        self.handle_message(message)?;
                     }
                 }
             }
@@ -94,14 +94,14 @@ where
         Ok(())
     }
 
-    fn handle_message(&mut self, message: Message) {
+    fn handle_message(&mut self, message: Message) -> Result<()> {
         match message {
             Message::Request(id, request) => self.handle_request(id, request),
             Message::Notification(notification) => self.handle_notification(notification),
         }
     }
 
-    fn handle_request(&mut self, id: lsp_server::RequestId, request: Request) {
+    fn handle_request(&mut self, id: lsp_server::RequestId, request: Request) -> Result<()> {
         let (outcome, feedback) = match request {
             Request::Format(param) => self.format(param),
             Request::Hover(param) => self.hover(param),
@@ -119,7 +119,7 @@ where
             Request::RenameFiles(param) => self.rename_files(param),
         };
 
-        self.publish_feedback(feedback);
+        self.publish_feedback(feedback)?;
 
         let response = match outcome {
             Ok(payload) => lsp_server::Response {
@@ -137,10 +137,13 @@ where
         self.connection
             .sender
             .send(lsp_server::Message::Response(response))
-            .expect("channel send LSP response");
+            .map_err(|error| gleam_core::Error::LspMessageSendFailed {
+                error: error.to_string(),
+            })?;
+        Ok(())
     }
 
-    fn handle_notification(&mut self, notification: Notification) {
+    fn handle_notification(&mut self, notification: Notification) -> Result<()> {
         let feedback = match notification {
             Notification::CompilePlease => self.compile_please(),
             Notification::SourceFileOpened { path, text } => self.source_file_opened(path, text),
@@ -151,15 +154,19 @@ where
             }
             Notification::ConfigFileChanged { path } => self.watched_files_changed(path),
         };
-        self.publish_feedback(feedback);
+        self.publish_feedback(feedback)
     }
 
-    fn publish_feedback(&self, feedback: Feedback) {
-        self.publish_diagnostics(feedback.diagnostics);
-        self.publish_messages(feedback.messages);
+    fn publish_feedback(&self, feedback: Feedback) -> Result<()> {
+        self.publish_diagnostics(feedback.diagnostics)?;
+        self.publish_messages(feedback.messages)?;
+        Ok(())
     }
 
-    fn publish_diagnostics(&self, diagnostics: HashMap<Utf8PathBuf, Vec<Diagnostic>>) {
+    fn publish_diagnostics(
+        &self,
+        diagnostics: HashMap<Utf8PathBuf, Vec<Diagnostic>>,
+    ) -> Result<()> {
         for (path, diagnostics) in diagnostics {
             let diagnostics = diagnostics
                 .into_iter()
@@ -181,11 +188,14 @@ where
             self.connection
                 .sender
                 .send(lsp_server::Message::Notification(notification))
-                .expect("send textDocument/publishDiagnostics");
+                .map_err(|error| gleam_core::Error::LspMessageSendFailed {
+                    error: error.to_string(),
+                })?;
         }
+        Ok(())
     }
 
-    fn start_watching_gleam_toml(&mut self) {
+    fn start_watching_gleam_toml(&mut self) -> Result<()> {
         let supports_watch_files = self
             .initialise_params
             .capabilities
@@ -197,7 +207,7 @@ where
 
         if !supports_watch_files {
             tracing::warn!("lsp_client_cannot_watch_gleam_toml");
-            return;
+            return Ok(());
         }
 
         // Register gleam.toml as a watched file so we get a notification when
@@ -226,10 +236,13 @@ where
         self.connection
             .sender
             .send(lsp_server::Message::Request(request))
-            .expect("send client/registerCapability");
+            .map_err(|error| gleam_core::Error::LspMessageSendFailed {
+                error: error.to_string(),
+            })?;
+        Ok(())
     }
 
-    fn publish_messages(&self, messages: Vec<Diagnostic>) {
+    fn publish_messages(&self, messages: Vec<Diagnostic>) -> Result<()> {
         for message in messages {
             let params = lsp::ShowMessageParams {
                 kind: match message.level {
@@ -245,8 +258,11 @@ where
             self.connection
                 .sender
                 .send(lsp_server::Message::Notification(notification))
-                .expect("send window/showMessage");
+                .map_err(|error| gleam_core::Error::LspMessageSendFailed {
+                    error: error.to_string(),
+                })?;
         }
+        Ok(())
     }
 
     fn respond_with_engine<T, Handler>(
@@ -534,7 +550,7 @@ where
     }
 }
 
-fn initialisation_handshake(connection: &lsp_server::Connection) -> InitializeParams {
+fn initialisation_handshake(connection: &lsp_server::Connection) -> Result<InitializeParams> {
     let server_capabilities = lsp::ServerCapabilities {
         text_document_sync: Some(
             lsp::TextDocumentSyncOptions {
@@ -631,12 +647,15 @@ fn initialisation_handshake(connection: &lsp_server::Connection) -> InitializePa
     };
     let server_capabilities_json =
         serde_json::to_value(server_capabilities).expect("server_capabilities_serde");
-    let initialise_params_json = connection
-        .initialize(server_capabilities_json)
-        .expect("LSP initialize");
+    let initialise_params_json =
+        connection
+            .initialize(server_capabilities_json)
+            .map_err(|error| gleam_core::Error::LspMessageReceiveFailed {
+                error: error.to_string(),
+            })?;
     let initialise_params: InitializeParams =
         serde_json::from_value(initialise_params_json).expect("LSP InitializeParams from json");
-    initialise_params
+    Ok(initialise_params)
 }
 
 fn diagnostic_to_lsp(diagnostic: Diagnostic) -> Vec<lsp::Diagnostic> {


### PR DESCRIPTION
- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes

Closes #6144

Replaces `.expect()` on LSP transport operations (initialize, recv, send) with a dedicated `Error::LspTransport` variant, `Next::Stop`, and `let _ =` to exit cleanly on client disconnect.