### PR TITLE
Add Wasm source formatting export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,12 @@
 
 ### Formatter
 
+### Compiler Wasm API
+
+- The WebAssembly build of the compiler now exposes a `format_source` function
+  for formatting Gleam source code.
+  ([John Downey](https://github.com/jtdowney))
+
 ### Bug fixes
 
 - Fixed a bug where on the JavaScript target a case clause whose guard's top

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1387,6 +1387,7 @@ dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.15",
  "gleam-core",
+ "gleam-format",
  "hexpm",
  "im",
  "itertools 0.15.0",

--- a/compiler-wasm/Cargo.toml
+++ b/compiler-wasm/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 gleam-core = { path = "../compiler-core" }
+gleam-format = { path = "../format" }
 console_error_panic_hook = "0"
 serde-wasm-bindgen = "0"
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }

--- a/compiler-wasm/src/lib.rs
+++ b/compiler-wasm/src/lib.rs
@@ -5,7 +5,7 @@
 mod tests;
 mod wasm_filesystem;
 
-use camino::Utf8PathBuf;
+use camino::{Utf8Path, Utf8PathBuf};
 use gleam_core::{
     Error,
     analyse::TargetSupport,
@@ -165,6 +165,16 @@ pub fn reset_warnings(project_id: usize) {
 #[wasm_bindgen]
 pub fn pop_warning(project_id: usize) -> Option<String> {
     get_warnings(project_id).pop().map(|w| w.to_pretty_string())
+}
+
+/// Format the given source code using the Gleam formatter.
+///
+#[wasm_bindgen]
+pub fn format_source(source: &str) -> Result<String, String> {
+    let mut output = String::new();
+    gleam_format::pretty(&mut output, &source.into(), Utf8Path::new("<stdin>"))
+        .map_err(|e| e.pretty_string())?;
+    Ok(output)
 }
 
 fn do_compile_package(project: Project, target: Target) -> Result<(), Error> {

--- a/compiler-wasm/src/tests.rs
+++ b/compiler-wasm/src/tests.rs
@@ -6,6 +6,26 @@ use super::*;
 use wasm_bindgen_test::wasm_bindgen_test;
 
 #[wasm_bindgen_test]
+fn test_format_source() {
+    let source = "// Keep this comment\npub fn main(){1}";
+    let mut expected = String::new();
+    gleam_format::pretty(
+        &mut expected,
+        &source.into(),
+        camino::Utf8Path::new("<stdin>"),
+    )
+    .expect("format source with the CLI formatter API");
+
+    assert_eq!(expected, "// Keep this comment\npub fn main() {\n  1\n}\n");
+    assert_eq!(format_source(source), Ok(expected));
+}
+
+#[wasm_bindgen_test]
+fn test_format_source_invalid_source() {
+    assert!(format_source("pub fn main(").is_err());
+}
+
+#[wasm_bindgen_test]
 fn test_reset_filesystem() {
     reset_filesystem(0);
     assert_eq!(read_file_bytes(0, "hello"), None);


### PR DESCRIPTION
This is the first step towards gleam-lang/playground#3. I wasn't sure where to put the changelog entry, but the precedent in the early changelogs was a section for the Wasm API.

- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes
