### PR TITLE
Rename `Record` type in generated Erlang code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,11 @@
 
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- When generating Erlang type definitions, types called `Record` will be renamed
+  to `record_` to not overwrite Erlang's built-in `record` type introduced in
+  OTP29.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 - The compiler now provides a specific error message directing the user to the
   correct syntax when trying to update a record after providing fields.
   ([0xda157](https://github.com/0xda157))

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -4159,6 +4159,7 @@ fn erl_safe_type_name(mut name: EcoString) -> EcoString {
         | "pid"
         | "port"
         | "pos_integer"
+        | "record"
         | "reference"
         | "string"
         | "term"

--- a/compiler-core/src/erlang/tests/records.rs
+++ b/compiler-core/src/erlang/tests/records.rs
@@ -472,3 +472,9 @@ pub fn main() {
 "#
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/6180
+#[test]
+fn type_called_record_does_not_overwrite_erlang_builtin_record_type() {
+    assert_erl!("pub type Record { Record(Int) }")
+}

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__type_called_record_does_not_overwrite_erlang_builtin_record_type.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__records__type_called_record_does_not_overwrite_erlang_builtin_record_type.snap
@@ -1,0 +1,13 @@
+---
+source: compiler-core/src/erlang/tests/records.rs
+expression: "pub type Record { Record(Int) }"
+---
+----- SOURCE CODE
+pub type Record { Record(Int) }
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_ignored, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
+-export_type([record_/0]).
+
+-type record_() :: {record, integer()}.


### PR DESCRIPTION
This PR fixes #6180 
I'm wondering, is this considered a breaking change? If someone were relying on that generated type would their code break now?

- [X] The changes in this PR have been discussed beforehand in an issue
- [X] The issue for this PR has been linked
- [X] Tests have been added for new behaviour
- [X] The changelog has been updated for any user-facing changes
