### PR TITLE
Deprecate empty string bit array segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,10 @@
   through further usages.
   ([James Dolan](https://github.com/jamesdolan16))
 
+- Matching on bit array patterns which contain empty string segments is now
+  deprecated.
+  ([Surya Rose](https://github.com/GearsDatapacks))
+
 ### Build tool
 
 - The build tool now stores its build cache in a more compact binary format,

--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -1254,6 +1254,10 @@ pub enum Warning {
     PipeIntoCallWhichReturnsFunction {
         location: SrcSpan,
     },
+
+    EmptyStringBitArraySegment {
+        location: SrcSpan,
+    },
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
@@ -1529,7 +1533,8 @@ impl Warning {
             | Warning::RedundantComparison { location, .. }
             | Warning::JavaScriptBitArrayUnsafeInt { location, .. }
             | Warning::UnusedRecursiveArgument { location, .. }
-            | Warning::PipeIntoCallWhichReturnsFunction { location } => *location,
+            | Warning::PipeIntoCallWhichReturnsFunction { location }
+            | Warning::EmptyStringBitArraySegment { location } => *location,
         }
     }
 

--- a/compiler-core/src/type_/pattern.rs
+++ b/compiler-core/src/type_/pattern.rs
@@ -628,6 +628,11 @@ impl<'a, 'b> PatternTyper<'a, 'b> {
                     location: *location,
                 });
             }
+            Pattern::String { value, location } if value.is_empty() => {
+                self.problems.warning(Warning::EmptyStringBitArraySegment {
+                    location: *location,
+                });
+            }
             Pattern::Int { .. }
             | Pattern::Float { .. }
             | Pattern::String { .. }

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__empty_string_in_bit_array_pattern_segment.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__empty_string_in_bit_array_pattern_segment.snap
@@ -1,0 +1,24 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn go(x) {\n  case x {\n    <<\"\">> -> True\n    _ -> False\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn go(x) {
+  case x {
+    <<"">> -> True
+    _ -> False
+  }
+}
+
+
+----- WARNING
+warning: Empty string segment
+  ┌─ /src/warning/wrn.gleam:4:7
+  │
+4 │     <<"">> -> True
+  │       ^^ Remove this empty string
+
+This empty string segment is ignored in the pattern, so it can be safely
+removed. Empty string segments are deprecated and will become an error in a
+future version.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unreachable_empty_bit_array.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unreachable_empty_bit_array.snap
@@ -24,3 +24,13 @@ This pattern cannot be reached as a previous pattern matches the same
 values.
 
 Hint: It can be safely removed.
+
+warning: Empty string segment
+  ┌─ /src/warning/wrn.gleam:5:7
+  │
+5 │     <<"">> -> 2
+  │       ^^ Remove this empty string
+
+This empty string segment is ignored in the pattern, so it can be safely
+removed. Empty string segments are deprecated and will become an error in a
+future version.

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -5255,3 +5255,17 @@ pub fn thingy(wibble) {
     "#
     );
 }
+
+#[test]
+fn empty_string_in_bit_array_pattern_segment() {
+    assert_warning!(
+        r#"
+pub fn go(x) {
+  case x {
+    <<"">> -> True
+    _ -> False
+  }
+}
+"#
+    );
+}

--- a/compiler-core/src/warning.rs
+++ b/compiler-core/src/warning.rs
@@ -1570,6 +1570,26 @@ not be used.",
                         extra_labels: vec![],
                     }),
                 },
+
+                type_::Warning::EmptyStringBitArraySegment { location } => Diagnostic {
+                    title: "Empty string segment".into(),
+                    text: wrap(
+                        "This empty string segment is ignored in the pattern, \
+so it can be safely removed. Empty string segments are deprecated and will become \
+an error in a future version.",
+                    ),
+                    hint: None,
+                    level: diagnostic::Level::Warning,
+                    location: Some(Location {
+                        label: diagnostic::Label {
+                            text: Some("Remove this empty string".into()),
+                            span: *location,
+                        },
+                        path: path.clone(),
+                        src: src.clone(),
+                        extra_labels: vec![],
+                    }),
+                },
             },
 
             Warning::EmptyModule { path: _, name } => Diagnostic {

--- a/docs/v2.md
+++ b/docs/v2.md
@@ -76,3 +76,11 @@ JavaScript target where `0.0` is the same as `-0.0`.
 In Gleam v2 we want to make sure that `0.0` and `-0.0` are not considered equal
 on any target. This would mean using `Object.is` when checking equality on the
 JavaScript target.
+
+## Empty string bit array segments
+
+Bit arrays segments which match an empty string (`<<"">>`) are redundant can be
+removed without changing functionality (`<<>>` is equivalent). We already error
+for other zero-size segments, so we should make this consistent too.
+
+- [x] Emits warning when used.

--- a/language-server/src/code_action.rs
+++ b/language-server/src/code_action.rs
@@ -9451,7 +9451,8 @@ impl<'a> RemoveUnusedImports<'a> {
                 | type_::Warning::RedundantComparison { .. }
                 | type_::Warning::UnusedRecursiveArgument { .. }
                 | type_::Warning::JavaScriptBitArrayUnsafeInt { .. }
-                | type_::Warning::PipeIntoCallWhichReturnsFunction { .. } => None,
+                | type_::Warning::PipeIntoCallWhichReturnsFunction { .. }
+                | type_::Warning::EmptyStringBitArraySegment { .. } => None,
             })
             .sorted_by_key(|import| import.location())
             .collect_vec();


### PR DESCRIPTION
Closes #6185

- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes
