### PR TITLE
Reorder code actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,10 @@
   it.
   ([0xda157](https://github.com/0xda157))
 
+- The "add missing patterns" code action now has higher precedence than the code
+  action to discard an unused result.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Formatter
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@
   action to discard an unused result.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- The "pattern match on argument" code action now has higher precedence over the
+  "discard unused argument" code action.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Formatter
 
 ### Bug fixes

--- a/language-server/src/code_action.rs
+++ b/language-server/src/code_action.rs
@@ -5820,9 +5820,9 @@ impl<'a, IO> PatternMatchOnValue<'a, IO> {
 
         let mut action = Vec::with_capacity(1);
         CodeActionBuilder::new(action_title)
-            .kind(CodeActionKind::RefactorRewrite)
+            .kind(CodeActionKind::QuickFix)
             .changes(self.params.text_document.uri.clone(), self.edits.edits)
-            .preferred(false)
+            .preferred(true)
             .push_to(&mut action);
         action
     }

--- a/language-server/src/code_action.rs
+++ b/language-server/src/code_action.rs
@@ -12459,7 +12459,7 @@ impl<'a> WrapInAnonymousFunction<'a> {
                 .kind(CodeActionKind::RefactorRewrite)
                 .changes(
                     self.params.text_document.uri.clone(),
-                    self.edits.edits.drain(..).collect(),
+                    std::mem::take(&mut self.edits.edits),
                 )
                 .push_to(&mut actions);
         }
@@ -13198,7 +13198,7 @@ impl<'a> ConvertIntToDifferentBase<'a> {
                 .kind(CodeActionKind::RefactorRewrite)
                 .changes(
                     self.params.text_document.uri.clone(),
-                    self.edits.edits.drain(..).collect(),
+                    std::mem::take(&mut self.edits.edits),
                 )
                 .preferred(false)
                 .push_to(&mut action);

--- a/language-server/src/engine.rs
+++ b/language-server/src/engine.rs
@@ -460,7 +460,6 @@ where
 
             let lines = LineNumbers::new(&module.code);
 
-            code_action_unused_values(module, &lines, &params, &mut actions);
             actions.extend(RemoveUnusedImports::new(module, &lines, &params).code_actions());
             code_action_fix_names(module, &lines, &params, &this.error, &mut actions);
             code_action_import_module(module, &lines, &params, &this.error, &mut actions);
@@ -476,6 +475,7 @@ where
                 .extend(FixTruncatedBitArraySegment::new(module, &lines, &params).code_actions());
             actions.extend(RemovePrivateOpaque::new(module, &lines, &params).code_actions());
             actions.extend(AddMissingTypeParameter::new(module, &lines, &params).code_actions());
+            code_action_unused_values(module, &lines, &params, &mut actions);
             code_action_convert_qualified_constructor_to_unqualified(
                 module,
                 &this.compiler,


### PR DESCRIPTION
We noticed some useful code actions would end up being sorted lower than other more niche code actions. For example when hovering a non-exhaustive pattern matching expression we would prefer the first code action to be the one to add missing patterns, even though the case returns an unused result and "assign to _" makes sense too.

- [X] I've discussed this beforehand with Louis
- [X] The changelog has been updated for any user-facing changes
