### PR TITLE
Fix new clippy warning

### DIFF
--- a/language-server/src/code_action.rs
+++ b/language-server/src/code_action.rs
@@ -12459,7 +12459,7 @@ impl<'a> WrapInAnonymousFunction<'a> {
                 .kind(CodeActionKind::RefactorRewrite)
                 .changes(
                     self.params.text_document.uri.clone(),
-                    self.edits.edits.drain(..).collect(),
+                    std::mem::take(&mut self.edits.edits),
                 )
                 .push_to(&mut actions);
         }
@@ -13198,7 +13198,7 @@ impl<'a> ConvertIntToDifferentBase<'a> {
                 .kind(CodeActionKind::RefactorRewrite)
                 .changes(
                     self.params.text_document.uri.clone(),
-                    self.edits.edits.drain(..).collect(),
+                    std::mem::take(&mut self.edits.edits),
                 )
                 .preferred(false)
                 .push_to(&mut action);


### PR DESCRIPTION
I updated Rust to 1.98.0 and noticed a new Clippy warning. This fixes the issue, which was a reasonable recommendation.

```
❯ cargo clippy
warning: draining all elements of a collection into a new collection of the same type
     --> language-server/src/code_action.rs:12462:21
      |
12462 |                     self.edits.edits.drain(..).collect(),
      |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `mem::take` to avoid creating a new allocation: `std::mem::take(&mut self.edits.edits)`
      |
      = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.98.0/index.html#drain_collect
note: the lint level is defined here
     --> language-server/src/lib.rs:5:5
      |
    5 |     clippy::all,
      |     ^^^^^^^^^^^
      = note: `#[warn(clippy::drain_collect)]` implied by `#[warn(clippy::all)]`

warning: draining all elements of a collection into a new collection of the same type
     --> language-server/src/code_action.rs:13201:21
      |
13201 |                     self.edits.edits.drain(..).collect(),
      |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `mem::take` to avoid creating a new allocation: `std::mem::take(&mut self.edits.edits)`
      |
      = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.98.0/index.html#drain_collect

warning: `gleam-language-server` (lib) generated 2 warnings (run `cargo clippy --fix --lib -p gleam-language-server -- ` to apply 2 suggestions)
    Finished [`dev` profile [unoptimized + debuginfo]](https://doc.rust-lang.org/cargo/reference/profiles.html#default-profiles) target(s) in 0.34s
warning: the following packages contain code that will be rejected by a future version of Rust: proc-macro-error2 v2.0.1
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
```