### PR TITLE
Improve error message when adding a redundant dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,10 @@
 - Make links to Tangled repositories use their new domain & URL format.
   ([Naomi Roberts](https://github.com/naomieow))
 
+- The build tool now shows a better error when trying to add a package as a
+  dependency when it is already a development dependency (or vice-versa).
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 ### Language server
 
 - The "Generate dynamic decoder" code action is now only offered when the

--- a/compiler-cli/src/dependencies/dependency_manager.rs
+++ b/compiler-cli/src/dependencies/dependency_manager.rs
@@ -171,15 +171,58 @@ where
         let mut config = crate::config::read(paths.root_config())?;
         let project_name = config.name.clone();
 
-        // Insert the new packages to add, if it exists
-        if let Some((packages, dev)) = new_package {
-            for (package, requirement) in packages {
-                if dev {
-                    _ = config.dev_dependencies.insert(package, requirement);
-                } else {
-                    _ = config.dependencies.insert(package, requirement);
+        // Insert the new packages to add, if there's any
+        match new_package {
+            Some((packages_to_add, false)) => {
+                let mut already_existing_dev_packages = vec![];
+                for (package, requirement) in packages_to_add {
+                    if config.dev_dependencies.contains_key(&package) {
+                        already_existing_dev_packages.push(package);
+                    } else {
+                        _ = config.dependencies.insert(package, requirement);
+                    }
+                }
+
+                // If a dependency we want to add is a dev dependency already,
+                // then we want the whole process to fail and show an error
+                // message explaining why.
+                if !already_existing_dev_packages.is_empty() {
+                    return Err(Error::AddedDependenciesAreAlreadyDevDependencies {
+                        packages: already_existing_dev_packages,
+                    });
                 }
             }
+
+            Some((packages_to_add, true)) => {
+                let mut already_existing_packages = vec![];
+
+                for (package, requirement) in packages_to_add {
+                    match config.dependencies.get(&package) {
+                        // If the package exists already as a regular dependency
+                        // and it has the exact same requirement, then we can safely
+                        // ignore it. For example, we might have ran `gleam add wibble@1`
+                        // and later on run `gleam add wibble@1 --dev`.
+                        // This would do nothing!
+                        Some(existing_requirement) if *existing_requirement == requirement => (),
+
+                        // However, if the requirement is incompatible, we do want
+                        // to show an error. We can't just silently ignore it
+                        Some(_) => already_existing_packages.push(package),
+
+                        // If the package is not a dependency already we add it.
+                        None => {
+                            _ = config.dev_dependencies.insert(package, requirement);
+                        }
+                    }
+                }
+
+                if !already_existing_packages.is_empty() {
+                    return Err(Error::AddedDevDependenciesAreAlreadyDependencies {
+                        packages: already_existing_packages,
+                    });
+                }
+            }
+            None => (),
         }
 
         // Determine what versions we need

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -441,6 +441,18 @@ file_names.iter().map(|x| x.as_str()).join(", "))]
 
     #[error("could not create temp file: {error}")]
     CouldNotCreateTempFile { error: String },
+
+    /// This happens when we try adding some packages as regular dependencies
+    /// (gleam add wibble wobble ...) but those are already listed in the dev
+    /// dependencies of the project!
+    #[error("these packages are already dev dependencies: {packages:?}")]
+    AddedDependenciesAreAlreadyDevDependencies { packages: Vec<EcoString> },
+
+    /// This happens when we try adding some packages as dev dependencies
+    /// (gleam add wibble wobble ... --dev) but those are already listed in the
+    /// dependencies of the project!
+    #[error("these packages are already dependencies: {packages:?}")]
+    AddedDevDependenciesAreAlreadyDependencies { packages: Vec<EcoString> },
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
@@ -2564,6 +2576,88 @@ add `gleam add {name}` in this project."
                 location: None,
                 hint: None,
             }],
+
+            Error::AddedDependenciesAreAlreadyDevDependencies { packages } => {
+                match packages.as_slice() {
+                    [package] => vec![Diagnostic {
+                        title: "Package is already a dev dependency".into(),
+                        text: wrap_format!(
+                            "{package} is already a development dependency of this project."
+                        ),
+                        level: Level::Error,
+                        location: None,
+                        hint: Some(
+                            "If you want to use this package as a regular \
+dependency, you can move it to the `dependencies` section of this project's \
+`gleam.toml`."
+                                .into(),
+                        ),
+                    }],
+                    packages => vec![Diagnostic {
+                        title: "Packages are already dev dependencies".into(),
+                        text: wrap_format!(
+                            "{} are already develpment dependencies of this project.",
+                            comma_separated_list(packages)
+                        ),
+                        level: Level::Error,
+                        location: None,
+                        hint: Some(
+                            "If you want to use these packages as regular \
+dependencies, you can move them to the `dependencies` section of this project's \
+`gleam.toml`."
+                                .into(),
+                        ),
+                    }],
+                }
+            }
+
+            Error::AddedDevDependenciesAreAlreadyDependencies { packages } => {
+                match packages.as_slice() {
+                    [package] => vec![Diagnostic {
+                        title: "Package is already a dependency".into(),
+                        text: wrap_format!("{package} is already a dependency of this project."),
+                        level: Level::Error,
+                        location: None,
+                        hint: Some(
+                            "If you want to use this package as a development \
+dependency only, you can move it to the `dev_dependencies` section of this \
+project's `gleam.toml`."
+                                .into(),
+                        ),
+                    }],
+                    packages => vec![Diagnostic {
+                        title: "Packages are already dependencies".into(),
+                        text: wrap_format!(
+                            "{} are already dependencies of this project.",
+                            comma_separated_list(packages)
+                        ),
+                        level: Level::Error,
+                        location: None,
+                        hint: Some(
+                            "If you want to use these packages as development \
+dependencies only, you can move them to the `dev_dependencies` section of this \
+project's `gleam.toml`."
+                                .into(),
+                        ),
+                    }],
+                }
+            }
+        }
+    }
+}
+
+/// Turns a list of strings into a comma separated list of items with a final
+/// "and":
+/// - "wibble"
+/// - "wibble and wobble"
+/// - "wibble, wobble, and woo"
+fn comma_separated_list(items: &[EcoString]) -> String {
+    match items {
+        [] => String::new(),
+        [first, second] => format!("{first} and {second}"),
+        [first, ..] => {
+            let (last, items) = items.split_last().unwrap_or((first, &[]));
+            format!("{}, and {last}", items.iter().join(", "))
         }
     }
 }

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -2596,7 +2596,7 @@ dependency, you can move it to the `dependencies` section of this project's \
                     packages => vec![Diagnostic {
                         title: "Packages are already dev dependencies".into(),
                         text: wrap_format!(
-                            "{} are already develpment dependencies of this project.",
+                            "{} are already development dependencies of this project.",
                             comma_separated_list(packages)
                         ),
                         level: Level::Error,

--- a/compiler-core/src/error/snapshots/gleam_core__error__tests__added_dependencies_are_already_dev_dependencies.snap
+++ b/compiler-core/src/error/snapshots/gleam_core__error__tests__added_dependencies_are_already_dev_dependencies.snap
@@ -4,7 +4,7 @@ expression: error
 ---
 error: Packages are already dev dependencies
 
-wibble, wobble, and woo are already develpment dependencies of this
+wibble, wobble, and woo are already development dependencies of this
 project.
 
 Hint: If you want to use these packages as regular dependencies, you can

--- a/compiler-core/src/error/snapshots/gleam_core__error__tests__added_dependencies_are_already_dev_dependencies.snap
+++ b/compiler-core/src/error/snapshots/gleam_core__error__tests__added_dependencies_are_already_dev_dependencies.snap
@@ -1,0 +1,11 @@
+---
+source: compiler-core/src/error/tests.rs
+expression: error
+---
+error: Packages are already dev dependencies
+
+wibble, wobble, and woo are already develpment dependencies of this
+project.
+
+Hint: If you want to use these packages as regular dependencies, you can
+move them to the `dependencies` section of this project's `gleam.toml`.

--- a/compiler-core/src/error/snapshots/gleam_core__error__tests__added_dev_dependencies_are_already_dependencies.snap
+++ b/compiler-core/src/error/snapshots/gleam_core__error__tests__added_dev_dependencies_are_already_dependencies.snap
@@ -1,0 +1,11 @@
+---
+source: compiler-core/src/error/tests.rs
+expression: error
+---
+error: Packages are already dependencies
+
+wibble, wobble, and woo are already dependencies of this project.
+
+Hint: If you want to use these packages as development dependencies only,
+you can move them to the `dev_dependencies` section of this project's
+`gleam.toml`.

--- a/compiler-core/src/error/tests.rs
+++ b/compiler-core/src/error/tests.rs
@@ -258,3 +258,21 @@ fn lsp_message_receive_failed() {
     .pretty_string();
     assert_snapshot!(error);
 }
+
+#[test]
+fn added_dependencies_are_already_dev_dependencies() {
+    let error = Error::AddedDependenciesAreAlreadyDevDependencies {
+        packages: vec!["wibble".into(), "wobble".into(), "woo".into()],
+    }
+    .pretty_string();
+    assert_snapshot!(error);
+}
+
+#[test]
+fn added_dev_dependencies_are_already_dependencies() {
+    let error = Error::AddedDevDependenciesAreAlreadyDependencies {
+        packages: vec!["wibble".into(), "wobble".into(), "woo".into()],
+    }
+    .pretty_string();
+    assert_snapshot!(error);
+}


### PR DESCRIPTION
I noticed that the error message when adding a package that is already a dependency of the project as a dev dependency was not great. With this PR the build tool now produces a nicer error message explaining what's wrong!