### PR TITLE
Suggest aliases for already imported modules

### DIFF
--- a/compiler-core/src/type_/environment.rs
+++ b/compiler-core/src/type_/environment.rs
@@ -962,13 +962,9 @@ impl Environment<'_> {
                 }
 
                 match &imported {
-                    // Don't suggest importing modules if they are already imported
-                    _ if self
-                        .imported_modules
-                        .contains_key(importable.split('/').next_back().unwrap_or(importable)) =>
-                    {
-                        None
-                    }
+                    // This lookup uses the full module path, rather than its local
+                    // name, so it also detects modules imported with an alias.
+                    _ if self.names.is_module_imported(importable) => None,
                     Imported::Type(name) if module_info.get_public_type(name).is_some() => {
                         Some(ModuleSuggestion::Importable(importable.clone()))
                     }

--- a/compiler-core/src/type_/printer.rs
+++ b/compiler-core/src/type_/printer.rs
@@ -222,6 +222,10 @@ impl Names {
             .map(|(_, location)| location)
     }
 
+    pub fn is_module_imported(&self, module_name: &str) -> bool {
+        self.imported_modules.contains_key(module_name)
+    }
+
     /// Check whether a particular type alias is reexporting an internal type,
     /// and if so register it so we can print it correctly.
     pub fn maybe_register_reexport_alias(

--- a/compiler-core/src/type_/tests/errors.rs
+++ b/compiler-core/src/type_/tests/errors.rs
@@ -2287,6 +2287,19 @@ pub fn main() {
 }
 
 #[test]
+fn unknown_module_does_not_suggest_importing_module_imported_with_alias() {
+    assert_module_error!(
+        ("gleam/io", "pub fn println(message: String) {}"),
+        "
+import gleam/io as gleam_io
+pub fn main() {
+  io.println(\"Hello, world!\")
+}
+",
+    );
+}
+
+#[test]
 fn unknown_module_suggest_typo_for_unimported_module() {
     assert_module_error!(
         ("wibble/wobble", "pub fn wubble() {}"),

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_module_does_not_suggest_importing_module_imported_with_alias.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__errors__unknown_module_does_not_suggest_importing_module_imported_with_alias.snap
@@ -1,0 +1,24 @@
+---
+source: compiler-core/src/type_/tests/errors.rs
+expression: "\nimport gleam/io as gleam_io\npub fn main() {\n  io.println(\"Hello, world!\")\n}\n"
+---
+----- SOURCE CODE
+-- gleam/io.gleam
+pub fn println(message: String) {}
+
+-- main.gleam
+
+import gleam/io as gleam_io
+pub fn main() {
+  io.println("Hello, world!")
+}
+
+
+----- ERROR
+error: Unknown module
+  ┌─ /src/one/two.gleam:4:3
+  │
+4 │   io.println("Hello, world!")
+  │   ^^
+
+No module has been found with the name `io`.

--- a/language-server/src/tests/action.rs
+++ b/language-server/src/tests/action.rs
@@ -2931,6 +2931,24 @@ pub fn main() {
 }
 
 #[test]
+fn test_no_action_to_import_module_imported_with_alias() {
+    let src = r#"
+import gleam/io as gleam_io
+
+pub fn main() {
+  io.println("Hello, world!")
+}
+"#;
+
+    assert_no_code_actions!(
+        "Import `gleam/io`",
+        TestProject::for_source(src)
+            .add_hex_module("gleam/io", "pub fn println(message: String) {}"),
+        find_position_of("io.").select_until(find_position_of("println"))
+    );
+}
+
+#[test]
 fn test_import_similar_module() {
     let src = "
 pub fn main() {


### PR DESCRIPTION
- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [ ] The changelog has been updated for any user-facing changes

Closes #5908.

I updated the language server code action to replace the unknown module name with the existing alias.

Added regression tests to cover the compiler diagnostic and language server code action.