### PR TITLE
Fix optional dep resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,6 +242,11 @@
   declaration and the whole module failed to parse.
   ([John Downey](https://github.com/jtdowney))
 
+- Fixed a bug where a package's optional dependency requirements could be
+  ignored, or could pull a package into the dependency tree that nothing
+  actually required.
+  ([John Downey](https://github.com/jtdowney))
+
 ## v1.18.1 - 2026-08-01
 
 - Fixed a bug where the Erlang code generator would generate wrong code when

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,26 +19,57 @@ dependencies = [
 ]
 
 [[package]]
-name = "age"
-version = "0.11.3"
+name = "aes"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07d86e4272c093c88caf7864a2d09af52a5159180848ca4832a3cdbd7d014d5"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.12",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
+name = "age"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd290633c2482479f70f6d1d96ae0e9f52c6a26cd5859edd47ee1fe33fc89f26"
 dependencies = [
  "age-core",
- "base64 0.21.7",
+ "base64",
  "bech32",
  "chacha20poly1305",
+ "cipher",
  "cookie-factory",
+ "hkdf",
  "hmac",
+ "hpke",
  "i18n-embed",
  "i18n-embed-fl",
  "lazy_static",
- "nom",
+ "ml-kem",
+ "nom 8.0.0",
+ "p256",
  "pin-project",
  "rand 0.8.6",
  "rust-embed",
  "scrypt",
  "sha2",
+ "sha3",
  "subtle",
  "x25519-dalek",
  "zeroize",
@@ -46,16 +77,18 @@ dependencies = [
 
 [[package]]
 name = "age-core"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2bf6a89c984ca9d850913ece2da39e1d200563b0a94b002b253beee4c5acf99"
+checksum = "01d4375964d1501e5f1b32aef2ead573913893ff238448d4e9fdf1522d828656"
 dependencies = [
- "base64 0.21.7",
+ "base64",
+ "bech32",
  "chacha20poly1305",
  "cookie-factory",
  "hkdf",
+ "hpke",
  "io_tee",
- "nom",
+ "nom 8.0.0",
  "rand 0.8.6",
  "secrecy",
  "sha2",
@@ -163,7 +196,7 @@ dependencies = [
  "memchr",
  "proc-macro2",
  "quote",
- "rustc-hash 2.0.0",
+ "rustc-hash 2.1.3",
  "serde",
  "serde_derive",
  "syn 2.0.114",
@@ -184,7 +217,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7db09fde9143e7ac4513358fb32ee32847125b63b18ea715afd487956da715da"
 dependencies = [
- "rustc-hash 2.0.0",
+ "rustc-hash 2.1.3",
  "serde",
  "serde_derive",
  "unicode-ident",
@@ -200,7 +233,7 @@ dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
  "thiserror 2.0.18",
@@ -282,10 +315,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d27c3610c36aee21ce8ac510e6224498de4228ad772a171ed65643a24693a5a8"
 
 [[package]]
-name = "base64"
-version = "0.21.7"
+name = "base16ct"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
@@ -313,9 +346,9 @@ dependencies = [
 
 [[package]]
 name = "bech32"
-version = "0.9.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 
 [[package]]
 name = "bimap"
@@ -608,6 +641,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "cookie-factory"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -694,13 +733,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -741,20 +802,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown 0.14.3",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "data-encoding"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -777,6 +824,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
 name = "der-parser"
 version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,7 +841,7 @@ checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
  "asn1-rs",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-bigint 0.4.8",
  "num-traits",
  "rusticata-macros",
@@ -879,6 +936,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -935,6 +1011,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -984,9 +1070,9 @@ dependencies = [
 
 [[package]]
 name = "fluent"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb74634707bebd0ce645a981148e8fb8c7bccd4c33c652aeffd28bf2f96d555a"
+checksum = "8137a6d5a2c50d6b0ebfcb9aaa91a28154e0a70605f112d30cb0cd4a78670477"
 dependencies = [
  "fluent-bundle",
  "unic-langid",
@@ -994,16 +1080,16 @@ dependencies = [
 
 [[package]]
 name = "fluent-bundle"
-version = "0.15.3"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe0a21ee80050c678013f82edf4b705fe2f26f1f9877593d13198612503f493"
+checksum = "01203cb8918f5711e73891b347816d932046f95f54207710bda99beaeb423bf4"
 dependencies = [
  "fluent-langneg",
  "fluent-syntax",
  "intl-memoizer",
  "intl_pluralrules",
- "rustc-hash 1.1.0",
- "self_cell 0.10.3",
+ "rustc-hash 2.1.3",
+ "self_cell",
  "smallvec",
  "unic-langid",
 ]
@@ -1019,11 +1105,12 @@ dependencies = [
 
 [[package]]
 name = "fluent-syntax"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a530c4694a6a8d528794ee9bbd8ba0122e779629ac908d15ad5a7ae7763a33d"
+checksum = "54f0d287c53ffd184d04d8677f590f4ac5379785529e5e08b1c8083acdd5c198"
 dependencies = [
- "thiserror 1.0.69",
+ "memchr",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1171,6 +1258,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1210,6 +1298,16 @@ dependencies = [
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -1421,10 +1519,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.14.3"
+name = "group"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1507,6 +1610,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "hpke"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4917627a14198c3603282c5158b815ad5534795451d3c074b53cf3cee0960b11"
+dependencies = [
+ "aead",
+ "aes-gcm",
+ "chacha20poly1305",
+ "digest",
+ "generic-array",
+ "hkdf",
+ "hmac",
+ "p256",
+ "rand_core 0.6.4",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "http"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1522,7 +1645,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e92637d714ad90b81c91bce86e8c1f98fb32ca79bddf8d69e9d83fee3966946"
 dependencies = [
- "base64 0.22.1",
+ "base64",
 ]
 
 [[package]]
@@ -1563,6 +1686,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2d35805454dc9f8662a98d6d61886ffe26bd465f5960e0e55345c70d5c0d2a9"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1607,7 +1739,7 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -1641,9 +1773,9 @@ dependencies = [
 
 [[package]]
 name = "i18n-embed"
-version = "0.15.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7839d8c7bb8da7bd58c1112d3a1aeb7f178ff3df4ae87783e758ca3bfb750b7"
+checksum = "a217bbb075dcaefb292efa78897fc0678245ca67f265d12c351e42268fcb0305"
 dependencies = [
  "arc-swap",
  "fluent",
@@ -1651,7 +1783,6 @@ dependencies = [
  "fluent-syntax",
  "i18n-embed-impl",
  "intl-memoizer",
- "lazy_static",
  "log",
  "parking_lot",
  "rust-embed",
@@ -1662,18 +1793,16 @@ dependencies = [
 
 [[package]]
 name = "i18n-embed-fl"
-version = "0.9.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e9571c3cba9eba538eaa5ee40031b26debe76f0c7e17bafc97ea57a76cd82e"
+checksum = "602e6bd30c3db2749e13e38b363a3d98d9d41de1d8de7a79c31bb69e45b47cda"
 dependencies = [
- "dashmap",
  "find-crate",
  "fluent",
  "fluent-syntax",
  "i18n-config",
  "i18n-embed",
- "lazy_static",
- "proc-macro-error2",
+ "proc-macro-error3",
  "proc-macro2",
  "quote",
  "strsim",
@@ -1874,9 +2003,9 @@ dependencies = [
 
 [[package]]
 name = "intl-memoizer"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe22e020fce238ae18a6d5d8c502ee76a52a6e880d99477657e6acc30ec57bda"
+checksum = "310da2e345f5eb861e7a07ee182262e94975051db9e4223e909ba90f392f163f"
 dependencies = [
  "type-map",
  "unic-langid",
@@ -2015,6 +2144,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures 0.2.12",
+]
+
+[[package]]
+name = "kem"
+version = "0.3.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b8645470337db67b01a7f966decf7d0bafedbae74147d33e641c67a91df239f"
+dependencies = [
+ "rand_core 0.6.4",
+ "zeroize",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2143,6 +2291,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ml-kem"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de49b3df74c35498c0232031bb7e85f9389f913e2796169c8ab47a53993a18f"
+dependencies = [
+ "hybrid-array",
+ "kem",
+ "rand_core 0.6.4",
+ "sha3",
+]
+
+[[package]]
 name = "multimap"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2177,6 +2337,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2315,6 +2484,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f222829ae9293e33a9f5e9f440c6760a3d450a64affe1846486b140db81c1f4"
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "elliptic-curve",
+ "primeorder",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2418,6 +2597,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.12",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2470,6 +2661,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
 name = "priority-queue"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2481,25 +2681,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
+name = "proc-macro-error-attr3"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+checksum = "b0084e6206a967a2dad822180626b2f6b07a3b379325e8f1ec0438e33a469ba7"
 dependencies = [
  "proc-macro2",
  "quote",
 ]
 
 [[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
+name = "proc-macro-error3"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+checksum = "0cf066225f2373bc711684792b69bdeac0356019b007e721090c24d92d5d5a50"
 dependencies = [
- "proc-macro-error-attr2",
+ "proc-macro-error-attr3",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2603,7 +2803,7 @@ dependencies = [
  "indexmap",
  "log",
  "priority-queue",
- "rustc-hash 2.0.0",
+ "rustc-hash 2.1.3",
  "thiserror 2.0.18",
  "version-ranges",
 ]
@@ -2637,7 +2837,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.0.0",
+ "rustc-hash 2.1.3",
  "rustls",
  "socket2 0.6.0",
  "thiserror 2.0.18",
@@ -2659,7 +2859,7 @@ dependencies = [
  "rand 0.10.2",
  "rand_pcg",
  "ring",
- "rustc-hash 2.0.0",
+ "rustc-hash 2.1.3",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -2868,7 +3068,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-core",
  "http",
@@ -2974,9 +3174,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.0.0"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -3002,7 +3202,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -3144,6 +3344,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "secrecy"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3177,18 +3390,9 @@ dependencies = [
 
 [[package]]
 name = "self_cell"
-version = "0.10.3"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14e4d63b804dc0c7ec4a1e52bcb63f02c7ac94476755aa579edac21e01f915d"
-dependencies = [
- "self_cell 1.0.4",
-]
-
-[[package]]
-name = "self_cell"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d369a96f978623eb3dc28807c4852d6cc617fed53da5d3c400feff1ef34a714a"
+checksum = "2ab42ca02749e120097e328d91d415325bdf43b1c72c4c8badf37375fe40a813"
 
 [[package]]
 name = "semver"
@@ -3283,6 +3487,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.12",
  "digest",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+dependencies = [
+ "digest",
+ "keccak",
 ]
 
 [[package]]
@@ -3473,9 +3687,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -4529,7 +4743,7 @@ dependencies = [
  "data-encoding",
  "der-parser",
  "lazy_static",
- "nom",
+ "nom 7.1.3",
  "oid-registry",
  "rusticata-macros",
  "thiserror 2.0.18",

--- a/compiler-core/Cargo.toml
+++ b/compiler-core/Cargo.toml
@@ -38,7 +38,7 @@ id-arena = "2"
 # Bijective (bi-directional) hashmap
 bimap = { version = "0.6.3", features = ["serde"] }
 # Encryption
-age = { version = "0.11", features = ["armor"] }
+age = { version = "0.12", features = ["armor"] }
 radix_trie = "0.3"
 # Ensuring recursive type-checking doesn't stack overflow
 stacker = "0.1.21"

--- a/compiler-core/src/dependency.rs
+++ b/compiler-core/src/dependency.rs
@@ -1,7 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2023 The Gleam contributors
 
-use std::{cell::RefCell, cmp::Reverse, collections::HashMap, rc::Rc};
+use std::{
+    cell::RefCell,
+    cmp::{Ordering, Reverse},
+    collections::HashMap,
+    fmt,
+    ops::Bound,
+    rc::Rc,
+};
 
 use crate::{Error, Result, manifest};
 
@@ -10,12 +17,82 @@ use hexpm::{
     Dependency, Release,
     version::{Range, Version},
 };
-use pubgrub::{Dependencies, Map};
+use pubgrub::{Dependencies, DerivationTree, Map};
 use thiserror::Error;
 
 pub type PackageVersions = HashMap<String, Version>;
 
-type PubgrubRange = pubgrub::Range<Version>;
+type PubgrubRange = pubgrub::Range<Presence>;
+
+/// A resolved package version, or `Absent` when the package is not part of the
+/// dependency tree at all.
+///
+/// Hex's optional requirements do not pull a package in, they only constrain
+/// one that something else has already pulled in. pubgrub has no way to say
+/// "this package, if it is here at all", so absence is modelled as a version
+/// that only optional requirements admit. A package resolves to `Absent`
+/// exactly when every requirement on it was optional.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Presence {
+    Absent,
+    Present(Version),
+}
+
+/// `Absent` sorts below every version.
+///
+/// That ordering is what lets a requirement rule absence in or out.
+/// `to_presence_range` gives a mandatory requirement the lower bound
+/// `Bound::Excluded(Absent)`, which admits every version and nothing else.
+impl Ord for Presence {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (self, other) {
+            (Presence::Absent, Presence::Absent) => Ordering::Equal,
+            (Presence::Absent, Presence::Present(_)) => Ordering::Less,
+            (Presence::Present(_), Presence::Absent) => Ordering::Greater,
+            (Presence::Present(left), Presence::Present(right)) => left.cmp(right),
+        }
+    }
+}
+
+impl PartialOrd for Presence {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl fmt::Display for Presence {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Presence::Absent => write!(f, "absent"),
+            Presence::Present(version) => version.fmt(f),
+        }
+    }
+}
+
+/// Lift a requirement over Hex versions into one over `Presence`.
+///
+/// An unbounded lower end excludes `Absent`, so a mandatory requirement does
+/// not admit absence.
+fn to_presence_range(range: &pubgrub::Range<Version>) -> PubgrubRange {
+    range
+        .iter()
+        .map(|(lower, upper)| {
+            let lower = to_presence_bound(lower, Bound::Excluded(Presence::Absent));
+            let upper = to_presence_bound(upper, Bound::Unbounded);
+            PubgrubRange::from_range_bounds((lower, upper))
+        })
+        .fold(PubgrubRange::empty(), |range, segment| {
+            range.union(&segment)
+        })
+}
+
+fn to_presence_bound(bound: &Bound<Version>, unbounded: Bound<Presence>) -> Bound<Presence> {
+    match bound {
+        Bound::Unbounded => unbounded,
+        Bound::Included(version) => Bound::Included(Presence::Present(version.clone())),
+        Bound::Excluded(version) => Bound::Excluded(Presence::Present(version.clone())),
+    }
+}
 
 pub fn resolve_versions<Requirements>(
     package_fetcher: &impl PackageFetcher,
@@ -58,11 +135,17 @@ where
     let packages = pubgrub::resolve(
         &DependencyProvider::new(package_fetcher, provided_packages, root, locked, exact_deps),
         root_name.as_str().into(),
-        root_version,
+        Presence::Present(root_version),
     )
     .map_err(|error| Error::dependency_resolution_failed(error, root_name.clone()))?
     .into_iter()
-    .filter(|(name, _)| name.as_str() != root_name.as_str())
+    .filter_map(|(name, version)| match version {
+        // Packages that only ever had optional requirements on them are not
+        // part of the dependency tree.
+        Presence::Absent => None,
+        Presence::Present(_) if name.as_str() == root_name.as_str() => None,
+        Presence::Present(version) => Some((name, version)),
+    })
     .collect();
 
     Ok(packages)
@@ -294,7 +377,6 @@ pub struct DependencyProvider<'a, T: PackageFetcher> {
     // That default breaks on prerelease builds since a bump includes the whole
     // patch.
     exact_only: &'a HashMap<String, Version>,
-    optional_dependencies: RefCell<HashMap<EcoString, pubgrub::Range<Version>>>,
 }
 
 impl<'a, T> DependencyProvider<'a, T>
@@ -314,7 +396,6 @@ where
             locked,
             remote,
             exact_only,
-            optional_dependencies: RefCell::new(HashMap::new()),
         }
     }
 
@@ -354,6 +435,11 @@ where
 type PackageName = String;
 pub type ResolutionError<'a, T> = pubgrub::PubGrubError<DependencyProvider<'a, T>>;
 
+/// Why resolution could not find a set of versions that satisfies everything.
+///
+#[derive(Debug, Clone)]
+pub struct ResolutionFailure(pub(crate) DerivationTree<PackageName, PubgrubRange, String>);
+
 impl<T> pubgrub::DependencyProvider for DependencyProvider<'_, T>
 where
     T: PackageFetcher,
@@ -363,6 +449,10 @@ where
         package: &Self::P,
         version: &Self::V,
     ) -> Result<Dependencies<Self::P, Self::VS, Self::M>, Self::Err> {
+        let Presence::Present(version) = version else {
+            return Ok(Dependencies::Available(Map::default()));
+        };
+
         self.ensure_package_fetched(package)?;
         let packages = self.packages.borrow();
         let release = match packages
@@ -386,25 +476,19 @@ where
             )));
         }
 
+        let absent = PubgrubRange::singleton(Presence::Absent);
         let mut deps: Map<PackageName, PubgrubRange> = Map::default();
         for (name, dependency) in &release.requirements {
-            let mut range = dependency.requirement.to_pubgrub().clone();
-            let mut opt_deps = self.optional_dependencies.borrow_mut();
-            // if it's optional and it was not provided yet, store and skip
-            if dependency.optional && !packages.contains_key(name.as_str()) {
-                let _ = opt_deps
-                    .entry(name.into())
-                    .and_modify(|stored_range| {
-                        *stored_range = range.intersection(stored_range);
-                    })
-                    .or_insert(range);
-                continue;
-            }
-
-            // if a now required dep was optional before, add back the constraints
-            if let Some(other_range) = opt_deps.remove(name.as_str()) {
-                range = range.intersection(&other_range);
-            }
+            let requirement = to_presence_range(dependency.requirement.to_pubgrub());
+            // Admitting absence is the whole of what makes a requirement
+            // optional. pubgrub then intersects it with every other requirement
+            // on the package in the same pass, so the outcome does not depend
+            // on the order packages happen to be visited in.
+            let range = if dependency.optional {
+                requirement.union(&absent)
+            } else {
+                requirement
+            };
 
             let _ = deps.insert(name.clone(), range);
         }
@@ -424,10 +508,9 @@ where
                 .cloned()
                 .into_iter()
                 .flat_map(|package| {
-                    package
-                        .releases
-                        .into_iter()
-                        .filter(|release| range.contains(&release.version))
+                    package.releases.into_iter().filter(|release| {
+                        range.contains(&Presence::Present(release.version.clone()))
+                    })
                 })
                 .count(),
         )
@@ -438,6 +521,12 @@ where
         package: &Self::P,
         range: &Self::VS,
     ) -> std::result::Result<Option<Self::V>, Self::Err> {
+        // Nothing mandatory requires this package, so it stays out of the
+        // dependency tree and never needs fetching.
+        if range.contains(&Presence::Absent) {
+            return Ok(Some(Presence::Absent));
+        }
+
         self.ensure_package_fetched(package)?;
 
         let exact_package = self.exact_only.get(package);
@@ -458,20 +547,20 @@ where
                         _ => Some(release.version),
                     })
             })
-            .filter(|version| range.contains(version));
+            .filter(|version| range.contains(&Presence::Present(version.clone())));
         match potential_versions
             .clone()
             .filter(|version| !version.is_pre())
             .max()
         {
             // Don't resolve to a pre-releaase package unless we *have* to
-            Some(version) => Ok(Some(version)),
-            None => Ok(potential_versions.max()),
+            Some(version) => Ok(Some(Presence::Present(version))),
+            None => Ok(potential_versions.max().map(Presence::Present)),
         }
     }
 
     type P = PackageName;
-    type V = Version;
+    type V = Presence;
     type VS = PubgrubRange;
     type Priority = Reverse<usize>;
     type M = String;
@@ -542,6 +631,28 @@ mod tests {
                     vec![],
                     vec![("gleam_stdlib", ">= 0.1.0 and < 0.3.0")],
                 )],
+            ),
+            (
+                "package_with_optional_chain",
+                vec![release_with_optional(
+                    "0.1.0",
+                    vec![],
+                    vec![
+                        ("pkg_that_gains_a_dep", ">= 0.1.0 and < 0.2.0"),
+                        ("indirect_optional_target", ">= 0.1.0 and < 0.2.0"),
+                    ],
+                )],
+            ),
+            (
+                "pkg_that_gains_a_dep",
+                vec![
+                    release("0.1.0", vec![("indirect_optional_target", ">= 0.1.0")]),
+                    release("0.2.0", vec![]),
+                ],
+            ),
+            (
+                "indirect_optional_target",
+                vec![release("0.1.0", vec![]), release("0.2.0", vec![])],
             ),
             (
                 "direct_pkg_with_major_version",
@@ -698,6 +809,80 @@ mod tests {
                 ("gleam_stdlib".into(), Version::try_from("0.2.2").unwrap()),
                 (
                     "package_with_optional".into(),
+                    Version::try_from("0.1.0").unwrap()
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn resolution_with_optional_deps_not_pulled_in_by_provided_package() {
+        let gleam_stdlib = (*make_remote().get_dependencies("gleam_stdlib").unwrap()).clone();
+        let provided = vec![(EcoString::from("gleam_stdlib"), gleam_stdlib)]
+            .into_iter()
+            .collect();
+
+        let result = resolve_versions(
+            &make_remote(),
+            provided,
+            "app".into(),
+            vec![(
+                "package_with_optional".into(),
+                Range::new("~> 0.1".into()).unwrap(),
+            )]
+            .into_iter(),
+            &vec![].into_iter().collect(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            result,
+            vec![(
+                "package_with_optional".into(),
+                Version::try_from("0.1.0").unwrap()
+            )]
+            .into_iter()
+            .collect()
+        );
+    }
+
+    #[test]
+    fn resolution_with_optional_dep_on_package_pulled_in_by_another_optional_dep() {
+        let result = resolve_versions(
+            &make_remote(),
+            HashMap::new(),
+            "app".into(),
+            vec![
+                (
+                    "package_with_optional_chain".into(),
+                    Range::new("~> 0.1".into()).unwrap(),
+                ),
+                (
+                    "pkg_that_gains_a_dep".into(),
+                    Range::new("~> 0.1".into()).unwrap(),
+                ),
+            ]
+            .into_iter(),
+            &vec![].into_iter().collect(),
+        )
+        .unwrap()
+        .into_iter()
+        .sorted_by(|left, right| left.0.cmp(&right.0))
+        .collect_vec();
+
+        assert_eq!(
+            result,
+            vec![
+                (
+                    "indirect_optional_target".into(),
+                    Version::try_from("0.1.0").unwrap()
+                ),
+                (
+                    "package_with_optional_chain".into(),
+                    Version::try_from("0.1.0").unwrap()
+                ),
+                (
+                    "pkg_that_gains_a_dep".into(),
                     Version::try_from("0.1.0").unwrap()
                 ),
             ]
@@ -1239,6 +1424,91 @@ but it is locked to 0.2.0, which is incompatible."
                     "waa".into(),
                     Range::new(">= 2.0.0 and < 3.0.0".into()).unwrap(),
                 ),
+            ]
+            .into_iter(),
+            &vec![].into_iter().collect(),
+        );
+
+        if let Err(error @ Error::DependencyResolutionNoSolution { .. }) = result {
+            let message = error.pretty_string();
+            insta::assert_snapshot!(message)
+        } else {
+            panic!("expected a resolution error message")
+        }
+    }
+
+    #[test]
+    fn resolution_error_message_for_requirement_with_no_lower_bound() {
+        let remote = remote(vec![(
+            "wibble",
+            vec![release("1.2.0", vec![]), release("1.3.0", vec![])],
+        )]);
+
+        let result = resolve_versions(
+            &remote,
+            HashMap::new(),
+            "app".into(),
+            vec![("wibble".into(), Range::new("< 1.0.0".into()).unwrap())].into_iter(),
+            &vec![].into_iter().collect(),
+        );
+
+        if let Err(error @ Error::DependencyResolutionNoSolution { .. }) = result {
+            let message = error.pretty_string();
+            insta::assert_snapshot!(message)
+        } else {
+            panic!("expected a resolution error message")
+        }
+    }
+
+    #[test]
+    fn resolution_error_message_for_optional_requirement() {
+        let result = resolve_versions(
+            &make_remote(),
+            HashMap::new(),
+            "app".into(),
+            vec![
+                (
+                    "package_with_optional".into(),
+                    Range::new("~> 0.1".into()).unwrap(),
+                ),
+                ("gleam_stdlib".into(), Range::new("~> 0.3".into()).unwrap()),
+            ]
+            .into_iter(),
+            &vec![].into_iter().collect(),
+        );
+
+        if let Err(error @ Error::DependencyResolutionNoSolution { .. }) = result {
+            let message = error.pretty_string();
+            insta::assert_snapshot!(message)
+        } else {
+            panic!("expected a resolution error message")
+        }
+    }
+
+    #[test]
+    fn resolution_error_message_for_optional_requirement_with_no_lower_bound() {
+        let remote = remote(vec![
+            (
+                "wibble",
+                vec![release_with_optional(
+                    "1.0.0",
+                    vec![],
+                    vec![("wobble", "< 3.0.0")],
+                )],
+            ),
+            (
+                "wobble",
+                vec![release("2.0.0", vec![]), release("3.0.0", vec![])],
+            ),
+        ]);
+
+        let result = resolve_versions(
+            &remote,
+            HashMap::new(),
+            "app".into(),
+            vec![
+                ("wibble".into(), Range::new("~> 1.0".into()).unwrap()),
+                ("wobble".into(), Range::new(">= 3.0.0".into()).unwrap()),
             ]
             .into_iter(),
             &vec![].into_iter().collect(),

--- a/compiler-core/src/derivation_tree.rs
+++ b/compiler-core/src/derivation_tree.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2025 The Gleam contributors
 
+use crate::dependency::{Presence, ResolutionFailure};
 use crate::error::wrap;
 use ecow::EcoString;
 use hexpm::version::Version;
@@ -14,7 +15,7 @@ use pubgrub::External;
 use pubgrub::{DerivationTree, Derived, Ranges};
 use std::collections::HashMap;
 use std::hash::RandomState;
-use std::ops::Bound::{Excluded, Included, Unbounded};
+use std::ops::Bound::{self, Excluded, Included, Unbounded};
 use std::sync::Arc;
 
 macro_rules! wrap_format {
@@ -27,7 +28,7 @@ macro_rules! wrap_format {
 /// message.
 ///
 pub struct DerivationTreePrinter {
-    derivation_tree: DerivationTree<String, Ranges<Version>, String>,
+    derivation_tree: DerivationTree<String, Ranges<Presence>, String>,
 
     /// The name of the root package for which we're trying to add new
     /// dependencies. This is the starting point we use to find and report
@@ -44,7 +45,7 @@ pub struct DerivationTreePrinter {
     /// Means "package wibble with version `range1` requires package wobble
     /// with version `range2`".
     ///
-    dependencies: StableGraph<String, (Ranges<Version>, Ranges<Version>)>,
+    dependencies: StableGraph<String, (Ranges<Presence>, Ranges<Presence>)>,
 
     /// A map going from package name to its index in the dependencies graph.
     ///
@@ -52,10 +53,9 @@ pub struct DerivationTreePrinter {
 }
 
 impl DerivationTreePrinter {
-    pub fn new(
-        root_package_name: EcoString,
-        mut derivation_tree: DerivationTree<String, Ranges<Version>, String>,
-    ) -> Self {
+    pub fn new(root_package_name: EcoString, failure: ResolutionFailure) -> Self {
+        let ResolutionFailure(mut derivation_tree) = failure;
+
         // We start by trying to simplify the derivation tree as much as
         // possible.
         derivation_tree.collapse_no_versions();
@@ -200,7 +200,7 @@ impl DerivationTreePrinter {
         &self,
         one: &NodeIndex,
         other: &NodeIndex,
-    ) -> Option<(&Ranges<Version>, &Ranges<Version>)> {
+    ) -> Option<(&Ranges<Presence>, &Ranges<Presence>)> {
         let edge = self.dependencies.find_edge(*one, *other)?;
         self.dependencies
             .edge_weight(edge)
@@ -229,8 +229,8 @@ The conflicting packages are:
 }
 
 fn build_dependencies_graph(
-    derivation_tree: &DerivationTree<String, Ranges<Version>, String>,
-    graph: &mut StableGraph<String, (Ranges<Version>, Ranges<Version>)>,
+    derivation_tree: &DerivationTree<String, Ranges<Presence>, String>,
+    graph: &mut StableGraph<String, (Ranges<Presence>, Ranges<Presence>)>,
     nodes: &mut HashMap<String, NodeIndex<u32>>,
 ) {
     match derivation_tree {
@@ -299,7 +299,9 @@ fn build_dependencies_graph(
 /// This way we can print an error message that is way more concise and still
 /// informative about what went wrong, at the cost of
 ///
-fn simplify_derivation_tree(derivation_tree: &mut DerivationTree<String, Ranges<Version>, String>) {
+fn simplify_derivation_tree(
+    derivation_tree: &mut DerivationTree<String, Ranges<Presence>, String>,
+) {
     match derivation_tree {
         DerivationTree::External(_) => {}
         DerivationTree::Derived(derived) => {
@@ -311,7 +313,7 @@ fn simplify_derivation_tree(derivation_tree: &mut DerivationTree<String, Ranges<
 }
 
 fn simplify_derivation_tree_outer(
-    derivation_tree: &mut DerivationTree<String, Ranges<Version>, String>,
+    derivation_tree: &mut DerivationTree<String, Ranges<Presence>, String>,
 ) {
     match derivation_tree {
         DerivationTree::External(_) => {}
@@ -349,7 +351,7 @@ fn simplify_derivation_tree_outer(
 }
 
 fn collect_conflicting_packages<'dt>(
-    derivation_tree: &'dt DerivationTree<String, Ranges<Version>, String>,
+    derivation_tree: &'dt DerivationTree<String, Ranges<Presence>, String>,
     conflicting_packages: &mut HashSet<&'dt String>,
 ) {
     match derivation_tree {
@@ -371,9 +373,33 @@ fn collect_conflicting_packages<'dt>(
     }
 }
 
-fn pretty_range(range: &Ranges<Version>) -> String {
+/// Lower one segment of a resolver range back to the versions it talks about.
+///
+/// `Absent` is how optional requirements are modelled internally, so it carries
+/// no version a reader could act on. A segment that is only absence is dropped
+/// entirely, and absence as a lower end is just no lower bound at all.
+///
+fn without_absent<'range>(
+    (lower, upper): (&'range Bound<Presence>, &'range Bound<Presence>),
+) -> Option<(Bound<&'range Version>, Bound<&'range Version>)> {
+    let upper = match upper {
+        Included(Presence::Present(version)) => Included(version),
+        Excluded(Presence::Present(version)) => Excluded(version),
+        Unbounded => Unbounded,
+        Included(Presence::Absent) | Excluded(Presence::Absent) => return None,
+    };
+    let lower = match lower {
+        Included(Presence::Present(version)) => Included(version),
+        Excluded(Presence::Present(version)) => Excluded(version),
+        Included(Presence::Absent) | Excluded(Presence::Absent) | Unbounded => Unbounded,
+    };
+    Some((lower, upper))
+}
+
+fn pretty_range(range: &Ranges<Presence>) -> String {
     range
         .iter()
+        .filter_map(without_absent)
         .map(|(lower, upper)| match (lower, upper) {
             (Included(lower), Included(upper)) if lower == upper => format!("{lower}"),
             (Included(lower), Included(upper)) => format!(">= {lower} and <= {upper}"),
@@ -391,7 +417,7 @@ fn pretty_range(range: &Ranges<Version>) -> String {
         .join(" or ")
 }
 
-fn is_single_version(range: &Ranges<Version>) -> bool {
+fn is_single_version(range: &Ranges<Presence>) -> bool {
     // Note: at the time of writing this, `Ranges` has a method called
     // `as_singleton` which, according to its doc, should do the same thing.
     // However, it strangely seems to consider as a single version ranges like
@@ -400,7 +426,7 @@ fn is_single_version(range: &Ranges<Version>) -> bool {
 
     // The range needs to have exactly one segment that includes exactly one
     // version number.
-    let mut segments = range.iter();
+    let mut segments = range.iter().filter_map(without_absent);
     if let Some((Included(lower), Included(upper))) = segments.next()
         && segments.next().is_none()
     {

--- a/compiler-core/src/error.rs
+++ b/compiler-core/src/error.rs
@@ -5,10 +5,10 @@
 use crate::ast::{self};
 use crate::bit_array::UnsupportedOption;
 use crate::build::{Origin, Outcome, Runtime, Target};
-use crate::dependency::{PackageFetcher, ResolutionError};
+use crate::dependency::{PackageFetcher, ResolutionError, ResolutionFailure};
+use crate::derivation_tree::DerivationTreePrinter;
 use crate::diagnostic::{Diagnostic, ExtraLabel, Label, Location};
 
-use crate::derivation_tree::DerivationTreePrinter;
 use crate::parse::error::ParseErrorDetails;
 use crate::strings::{to_snake_case, to_upper_camel_case};
 use crate::type_::collapse_links;
@@ -319,8 +319,7 @@ file_names.iter().map(|x| x.as_str()).join(", "))]
     #[error("Could not find versions that satisfy dependency requirements")]
     DependencyResolutionNoSolution {
         root_package_name: EcoString,
-        derivation_tree:
-            Box<NeverEqual<pubgrub::DerivationTree<String, pubgrub::Ranges<Version>, String>>>,
+        derivation_tree: Box<NeverEqual<ResolutionFailure>>,
     },
 
     #[error("Dependency resolution failed: {0}")]
@@ -590,7 +589,7 @@ impl Error {
         match error {
             ResolutionError::NoSolution(derivation_tree) => Self::DependencyResolutionNoSolution {
                 root_package_name,
-                derivation_tree: Box::new(NeverEqual(derivation_tree)),
+                derivation_tree: Box::new(NeverEqual(ResolutionFailure(derivation_tree))),
             },
 
             ResolutionError::ErrorRetrievingDependencies {

--- a/compiler-core/src/snapshots/gleam_core__dependency__tests__resolution_error_message_for_optional_requirement.snap
+++ b/compiler-core/src/snapshots/gleam_core__dependency__tests__resolution_error_message_for_optional_requirement.snap
@@ -1,0 +1,10 @@
+---
+source: compiler-core/src/dependency.rs
+expression: message
+---
+error: Dependency resolution failed
+
+There's no compatible version of `gleam_stdlib`:
+  - You require package_with_optional >= 0.1.0 and < 1.0.0
+    - package_with_optional requires gleam_stdlib >= 0.1.0 and < 0.3.0
+  - You require gleam_stdlib >= 0.3.0 and < 1.0.0

--- a/compiler-core/src/snapshots/gleam_core__dependency__tests__resolution_error_message_for_optional_requirement_with_no_lower_bound.snap
+++ b/compiler-core/src/snapshots/gleam_core__dependency__tests__resolution_error_message_for_optional_requirement_with_no_lower_bound.snap
@@ -1,0 +1,10 @@
+---
+source: compiler-core/src/dependency.rs
+expression: message
+---
+error: Dependency resolution failed
+
+There's no compatible version of `wobble`:
+  - You require wibble >= 1.0.0 and < 2.0.0
+    - wibble requires wobble < 3.0.0
+  - You require wobble >= 3.0.0

--- a/compiler-core/src/snapshots/gleam_core__dependency__tests__resolution_error_message_for_requirement_with_no_lower_bound.snap
+++ b/compiler-core/src/snapshots/gleam_core__dependency__tests__resolution_error_message_for_requirement_with_no_lower_bound.snap
@@ -1,0 +1,7 @@
+---
+source: compiler-core/src/dependency.rs
+expression: message
+---
+error: Dependency resolution failed
+
+The package `wibble` has no versions in the range < 1.0.0.

--- a/deny.toml
+++ b/deny.toml
@@ -11,24 +11,6 @@ db-urls = ["https://github.com/rustsec/advisory-db"]
 # is to ensure that we do not forget to fix these.
 #
 [[advisories.ignore]]
-id = "RUSTSEC-2026-0173"
-reason = """
-proc-macro-error2 is currently unmaintained.
-
-At time of writing, it is used by a single transitive dependency.
-
-   $ cargo tree -i proc-macro-error2
-   proc-macro-error2 v2.0.1
-   └── i18n-embed-fl v0.9.2
-       └── age v0.11.3
-           └── gleam-core
-
-https://github.com/gleam-lang/gleam/issues/5829
-
-FIX-DEADLINE: 2026-10-08
-"""
-
-[[advisories.ignore]]
 id = "RUSTSEC-2026-0255"
 reason = """
 sized-chunks (used by im):


### PR DESCRIPTION
Closes #5829

While investigating #5829, I found the real reason the resolution tests destabilized. Upgrading `age` to 0.12 forces `rustc-hash` from 2.0.0 to 2.1.x, and `pubgrub`'s `Map` type is an `FxHashMap`. FxHasher iteration order is deterministic for a given `rustc-hash` version, but it is arbitrary, and 2.1 changed the hash function. The order pubgrub visits packages in changed, and some resolution tests started failing.

That only exposed the bug. The old code decided whether to apply an optional requirement by checking `!packages.contains_key(name)`, where `packages` is the lazily populated fetch cache, used as a proxy for "is this package in the solve":

https://github.com/gleam-lang/gleam/blob/68326fc52ba7ea44a6e5affe1a4047dd8bc84396/compiler-core/src/dependency.rs#L389-L410

Since `packages` caches what has been requested, if pubgrub tries a candidate version whose deps make it fetch `wibble` and then backtracks away from that branch entirely, `wibble` remains in the cache. Any optional requirement on `wibble` examined afterward sees `contains_key == true` and becomes a hard requirement, forcing `wibble` back into the tree that had just discarded it

This change remodels pubgrub's version type as either present or absent, with `Absent` as a sentinel that sorts below every real version. An optional requirement contributes `{Absent} U range` as its constraint, so it is satisfied either by the package staying out of the solve or by a version in the range. A mandatory requirement excludes `Absent`, so when pubgrub intersects a package's constraints, one mandatory requirement rules out absence, and the optional ranges then apply as ordinary version constraints.

- [ ] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes
