### PR TITLE
hexpm: remove abbreviations & simplify code

### DIFF
--- a/hexpm/src/lib.rs
+++ b/hexpm/src/lib.rs
@@ -891,7 +891,6 @@ fn proto_to_release(
 ) -> Result<Release<()>, ApiError> {
     let dependencies = release
         .dependencies
-        .clone()
         .into_iter()
         .map(proto_to_dep)
         .collect::<Result<HashMap<_, _>, _>>()?;

--- a/hexpm/src/lib.rs
+++ b/hexpm/src/lib.rs
@@ -865,15 +865,20 @@ fn proto_to_retirement_reason(reason: proto::package::RetirementReason) -> Retir
 }
 
 fn proto_to_dep(dep: proto::package::Dependency) -> Result<(String, Dependency), ApiError> {
-    let app = dep.app;
-    let repository = dep.repository;
-    let requirement = Range::new(dep.requirement.clone())
-        .map_err(|_| ApiError::InvalidVersionFormat(dep.requirement))?;
+    let proto::package::Dependency {
+        app,
+        package,
+        requirement,
+        optional,
+        repository,
+    } = dep;
+    let requirement =
+        Range::new(requirement.clone()).map_err(|_| ApiError::InvalidVersionFormat(requirement))?;
     Ok((
-        dep.package,
+        package,
         Dependency {
             requirement,
-            optional: dep.optional.is_some(),
+            optional: optional.is_some(),
             app,
             repository,
         },

--- a/hexpm/src/lib.rs
+++ b/hexpm/src/lib.rs
@@ -896,8 +896,8 @@ fn proto_to_release(
         .into_iter()
         .map(proto_to_dependency)
         .collect::<Result<HashMap<_, _>, _>>()?;
-    let version = Version::try_from(release.version.as_str())
-        .expect("Failed to parse version format from Hex");
+    let version =
+        Version::try_from(release.version.as_str()).expect("valid version format from Hex");
     let security_advisories = release
         .advisory_indexes
         .iter()

--- a/hexpm/src/lib.rs
+++ b/hexpm/src/lib.rs
@@ -325,17 +325,17 @@ pub fn repository_v2_get_versions_body(
     let versions = Versions::decode(payload.as_slice())?
         .packages
         .into_iter()
-        .map(|n| {
-            let parse_version = |v: &str| {
-                let err = |_| ApiError::InvalidVersionFormat(v.to_string());
-                Version::parse(v).map_err(err)
+        .map(|package| {
+            let parse_version = |version: &str| {
+                let error = |_| ApiError::InvalidVersionFormat(version.to_string());
+                Version::parse(version).map_err(error)
             };
-            let versions = n
+            let versions = package
                 .versions
                 .iter()
-                .map(|v| parse_version(v.as_str()))
+                .map(|version| parse_version(version.as_str()))
                 .collect::<Result<Vec<Version>, ApiError>>()?;
-            Ok((n.name, versions))
+            Ok((package.name, versions))
         })
         .collect::<Result<HashMap<_, _>, ApiError>>()?;
 
@@ -864,14 +864,16 @@ fn proto_to_retirement_reason(reason: proto::package::RetirementReason) -> Retir
     }
 }
 
-fn proto_to_dep(dep: proto::package::Dependency) -> Result<(String, Dependency), ApiError> {
+fn proto_to_dependency(
+    dependency: proto::package::Dependency,
+) -> Result<(String, Dependency), ApiError> {
     let proto::package::Dependency {
         app,
         package,
         requirement,
         optional,
         repository,
-    } = dep;
+    } = dependency;
     let requirement =
         Range::new(requirement.clone()).map_err(|_| ApiError::InvalidVersionFormat(requirement))?;
     Ok((
@@ -892,7 +894,7 @@ fn proto_to_release(
     let dependencies = release
         .dependencies
         .into_iter()
-        .map(proto_to_dep)
+        .map(proto_to_dependency)
         .collect::<Result<HashMap<_, _>, _>>()?;
     let version = Version::try_from(release.version.as_str())
         .expect("Failed to parse version format from Hex");

--- a/hexpm/src/tests.rs
+++ b/hexpm/src/tests.rs
@@ -249,11 +249,11 @@ fn remove_docs_response_rate_limited() {
 
 #[test]
 fn remove_docs_response_invalid_key() {
-    let resp_body = json!({
+    let response_body = json!({
         "message": "invalid API key",
         "status": 401,
     });
-    let response = make_json_response(401, resp_body);
+    let response = make_json_response(401, response_body);
     let result = crate::api_remove_docs_response(response).unwrap_err();
 
     match result {
@@ -264,11 +264,11 @@ fn remove_docs_response_invalid_key() {
 
 #[test]
 fn remove_docs_response_forbidden() {
-    let resp_body = json!({
+    let response_body = json!({
         "message": "account is not authorized for this action",
         "status": 403,
     });
-    let response = make_json_response(403, resp_body);
+    let response = make_json_response(403, response_body);
     let result = crate::api_remove_docs_response(response).unwrap_err();
 
     match result {
@@ -398,11 +398,11 @@ fn publish_docs_response_rate_limit() {
 
 #[test]
 fn publish_docs_response_invalid_api_key() {
-    let resp_body = json!({
+    let response_body = json!({
         "message": "invalid API key",
         "status": 401,
     });
-    let response = make_json_response(401, resp_body);
+    let response = make_json_response(401, response_body);
     let result = crate::api_publish_docs_response(response);
 
     match result {
@@ -413,10 +413,10 @@ fn publish_docs_response_invalid_api_key() {
 
 #[test]
 fn publish_docs_response_incorrect_totp_key() {
-    let resp_body = json!({
+    let response_body = json!({
         "status": 401,
     });
-    let mut response = make_json_response(401, resp_body);
+    let mut response = make_json_response(401, response_body);
     response.headers_mut().insert(
         "www-authenticate",
         "Bearer realm=\"hex\", error=\"invalid_totp\""
@@ -433,11 +433,11 @@ fn publish_docs_response_incorrect_totp_key() {
 
 #[test]
 fn publish_docs_response_forbidden() {
-    let resp_body = json!({
+    let response_body = json!({
         "message": "account is not authorized for this action",
         "status": 403,
     });
-    let response = make_json_response(403, resp_body);
+    let response = make_json_response(403, response_body);
     let result = crate::api_publish_docs_response(response);
 
     match result {
@@ -634,7 +634,7 @@ fn get_package_from_bytes_ok() {
 
 #[test]
 fn get_package_from_bytes_malformed() {
-    // public key should not be a valid protobuf and should therefore fail
+    // Public key should not be a valid protobuf and should therefore fail
     let bytes = std::include_bytes!("../test/public_key").to_vec();
     let package_error = crate::repository_v2_package_parse_body(&bytes, &bytes)
         .expect_err("parsing failed to fail");
@@ -713,7 +713,7 @@ fn get_repository_versions_from_bytes_ok() {
 
 #[test]
 fn get_repository_versions_from_bytes_malformed() {
-    // public key should not be a valid protobuf and should therefore fail
+    // Public key should not be a valid protobuf and should therefore fail
     let bytes = std::include_bytes!("../test/public_key").to_vec();
     let versions_error =
         crate::repository_v2_get_versions_body(&bytes, &bytes).expect_err("parsing failed to fail");
@@ -753,10 +753,10 @@ fn get_repository_tarball_response_bad_checksum() {
     let checksum = vec![1, 2, 3, 4, 5];
 
     let response = make_response(200, tarball_bytes.to_vec());
-    let err = crate::repository_get_package_tarball_response(response, &checksum).unwrap_err();
+    let error = crate::repository_get_package_tarball_response(response, &checksum).unwrap_err();
 
     assert_eq!(
-        err.to_string(),
+        error.to_string(),
         "The downloaded data did not have the expected checksum"
     );
 }
@@ -766,9 +766,9 @@ fn get_repository_tarball_response_not_found() {
     let checksum = vec![1, 2, 3, 4, 5];
 
     let response = make_response(404, vec![]);
-    let err = crate::repository_get_package_tarball_response(response, &checksum).unwrap_err();
+    let error = crate::repository_get_package_tarball_response(response, &checksum).unwrap_err();
 
-    assert_eq!(err.to_string(), "Resource was not found");
+    assert_eq!(error.to_string(), "Resource was not found");
 }
 
 #[test]
@@ -776,10 +776,10 @@ fn get_repository_tarball_response_rate_limited() {
     let checksum = vec![1, 2, 3, 4, 5];
 
     let response = make_response(429, vec![]);
-    let err = crate::repository_get_package_tarball_response(response, &checksum).unwrap_err();
+    let error = crate::repository_get_package_tarball_response(response, &checksum).unwrap_err();
 
     assert_eq!(
-        err.to_string(),
+        error.to_string(),
         "The rate limit for the Hex API has been exceeded"
     );
 }
@@ -840,12 +840,12 @@ fn publish_package_response_success() {
 
 #[test]
 fn modify_package_late() {
-    let resp_body = json!({
+    let response_body = json!({
         "errors": {"inserted_at": "can only modify a release up to one hour after publication"},
         "message": "Validation error(s)",
         "status": 422,
     });
-    let response = make_json_response(422, resp_body);
+    let response = make_json_response(422, response_body);
     let result = crate::api_publish_package_response(response);
 
     match result {
@@ -856,12 +856,12 @@ fn modify_package_late() {
 
 #[test]
 fn not_replacing() {
-    let resp_body = json!({
+    let response_body = json!({
         "errors": {"inserted_at": "must include the --replace flag to update an existing release"},
         "message": "Validation error(s)",
         "status": 422,
     });
-    let response = make_json_response(422, resp_body);
+    let response = make_json_response(422, response_body);
     let result = crate::api_publish_package_response(response);
 
     match result {
@@ -872,12 +872,12 @@ fn not_replacing() {
 
 #[test]
 fn unknown_error_422() {
-    let resp_body = json!({
+    let response_body = json!({
         "errors": {"tar": "file too big: metadata.config"},
         "message": "Validation error(s)",
         "status": 422,
     });
-    let response = make_json_response(422, resp_body);
+    let response = make_json_response(422, response_body);
     let result = crate::api_publish_package_response(response);
 
     match result {
@@ -912,7 +912,7 @@ fn get_package_release_response_not_found() {
 
 #[test]
 fn get_package_release_response_ok() {
-    let resp_body = json!({
+    let response_body = json!({
         "version": "0.0.1",
         "checksum": "41C6781B5F4B986BCE14C3578D39C497BCB8427F1D36D8CDE5FCAA6E03CAE2B1",
         "requirements": {
@@ -933,11 +933,11 @@ fn get_package_release_response_ok() {
             "build_tools": ["mix"]
         }
     });
-    let response = make_json_response(200, resp_body);
-    let resp = crate::api_get_package_release_response(response).unwrap();
+    let response = make_json_response(200, response_body);
+    let response = crate::api_get_package_release_response(response).unwrap();
 
     assert_eq!(
-        resp,
+        response,
         Release {
             version: Version::new(0, 0, 1),
             security_advisories: vec![],
@@ -1013,24 +1013,27 @@ fn oauth_device_authorisation_request() {
 #[test]
 fn oauth_device_authorisation_response_success() {
     let client_id = "test-client-id".to_string();
-    let resp_body = json!({
+    let response_body = json!({
         "device_code": "device-code-123",
         "user_code": "USER-CODE",
         "verification_uri": "https://hex.pm/oauth/device",
         "interval": 5
     });
 
-    let response = make_json_response(200, resp_body);
-    let auth = crate::oauth_device_authorisation_response(client_id, response).unwrap();
+    let response = make_json_response(200, response_body);
+    let authorisation = crate::oauth_device_authorisation_response(client_id, response).unwrap();
 
-    assert_eq!(auth.user_code, "USER-CODE");
-    assert_eq!(auth.verification_uri, "https://hex.pm/oauth/device");
+    assert_eq!(authorisation.user_code, "USER-CODE");
+    assert_eq!(
+        authorisation.verification_uri,
+        "https://hex.pm/oauth/device"
+    );
 }
 
 #[test]
 fn oauth_device_authorisation_response_success_with_complete_uri() {
     let client_id = "test-client-id".to_string();
-    let resp_body = json!({
+    let response_body = json!({
         "device_code": "device-code-123",
         "user_code": "USER-CODE",
         "verification_uri": "https://hex.pm/oauth/device",
@@ -1038,13 +1041,13 @@ fn oauth_device_authorisation_response_success_with_complete_uri() {
         "interval": 5
     });
 
-    let response = make_json_response(200, resp_body);
-    let auth = crate::oauth_device_authorisation_response(client_id, response).unwrap();
+    let response = make_json_response(200, response_body);
+    let authorisation = crate::oauth_device_authorisation_response(client_id, response).unwrap();
 
-    assert_eq!(auth.user_code, "USER-CODE");
+    assert_eq!(authorisation.user_code, "USER-CODE");
     // When verification_uri_complete is present, it should be used instead
     assert_eq!(
-        auth.verification_uri,
+        authorisation.verification_uri,
         "https://hex.pm/oauth/device?user_code=USER-CODE"
     );
 }
@@ -1053,17 +1056,20 @@ fn oauth_device_authorisation_response_success_with_complete_uri() {
 fn oauth_device_authorisation_response_default_interval() {
     let client_id = "test-client-id".to_string();
     // Response without "interval" field - should use default of 5 seconds
-    let resp_body = json!({
+    let response_body = json!({
         "device_code": "device-code-123",
         "user_code": "USER-CODE",
         "verification_uri": "https://hex.pm/oauth/device"
     });
 
-    let response = make_json_response(200, resp_body);
-    let auth = crate::oauth_device_authorisation_response(client_id, response).unwrap();
+    let response = make_json_response(200, response_body);
+    let authorisation = crate::oauth_device_authorisation_response(client_id, response).unwrap();
 
-    assert_eq!(auth.user_code, "USER-CODE");
-    assert_eq!(auth.verification_uri, "https://hex.pm/oauth/device");
+    assert_eq!(authorisation.user_code, "USER-CODE");
+    assert_eq!(
+        authorisation.verification_uri,
+        "https://hex.pm/oauth/device"
+    );
 }
 
 #[test]
@@ -1081,11 +1087,11 @@ fn oauth_device_authorisation_response_rate_limited() {
 #[test]
 fn oauth_device_authorisation_response_unexpected_status() {
     let client_id = "test-client-id".to_string();
-    let resp_body = json!({
+    let response_body = json!({
         "message": "Internal server error",
         "status": 500,
     });
-    let response = make_json_response(500, resp_body);
+    let response = make_json_response(500, response_body);
     let result = crate::oauth_device_authorisation_response(client_id, response).unwrap_err();
 
     match result {
@@ -1098,21 +1104,21 @@ fn oauth_device_authorisation_response_unexpected_status() {
 
 fn make_device_authorisation() -> crate::OAuthDeviceAuthorisation {
     let client_id = "test-client-id".to_string();
-    let resp_body = json!({
+    let response_body = json!({
         "device_code": "device-code-123",
         "user_code": "USER-CODE",
         "verification_uri": "https://hex.pm/oauth/device",
         "interval": 5
     });
-    let response = make_json_response(200, resp_body);
+    let response = make_json_response(200, response_body);
     crate::oauth_device_authorisation_response(client_id, response).unwrap()
 }
 
 #[test]
 fn poll_token_request() {
-    let auth = make_device_authorisation();
+    let authorisation = make_device_authorisation();
     let config = Config::new();
-    let request = auth.poll_token_request(&config);
+    let request = authorisation.poll_token_request(&config);
 
     assert_eq!(request.method(), http::Method::POST);
     assert_eq!(request.uri().path(), "/api/oauth/token");
@@ -1133,14 +1139,14 @@ fn poll_token_request() {
 
 #[test]
 fn poll_token_response_success() {
-    let mut auth = make_device_authorisation();
-    let resp_body = json!({
+    let mut authorisation = make_device_authorisation();
+    let response_body = json!({
         "access_token": "access-token-abc",
         "refresh_token": "refresh-token-xyz"
     });
-    let response = make_json_response(200, resp_body);
+    let response = make_json_response(200, response_body);
 
-    let result = auth.poll_token_response(response).unwrap();
+    let result = authorisation.poll_token_response(response).unwrap();
 
     match result {
         crate::PollStep::Done(tokens) => {
@@ -1153,13 +1159,13 @@ fn poll_token_response_success() {
 
 #[test]
 fn poll_token_response_authorization_pending() {
-    let mut auth = make_device_authorisation();
-    let resp_body = json!({
+    let mut authorisation = make_device_authorisation();
+    let response_body = json!({
         "error": "authorization_pending"
     });
-    let response = make_json_response(200, resp_body);
+    let response = make_json_response(200, response_body);
 
-    let result = auth.poll_token_response(response).unwrap();
+    let result = authorisation.poll_token_response(response).unwrap();
 
     match result {
         crate::PollStep::SleepThenPollAgain(duration) => {
@@ -1171,13 +1177,13 @@ fn poll_token_response_authorization_pending() {
 
 #[test]
 fn poll_token_response_slow_down() {
-    let mut auth = make_device_authorisation();
-    let resp_body = json!({
+    let mut authorisation = make_device_authorisation();
+    let response_body = json!({
         "error": "slow_down"
     });
-    let response = make_json_response(200, resp_body);
+    let response = make_json_response(200, response_body);
 
-    let result = auth.poll_token_response(response).unwrap();
+    let result = authorisation.poll_token_response(response).unwrap();
 
     match result {
         crate::PollStep::SleepThenPollAgain(duration) => {
@@ -1190,14 +1196,14 @@ fn poll_token_response_slow_down() {
 
 #[test]
 fn poll_token_response_unexpected_status() {
-    let mut auth = make_device_authorisation();
-    let resp_body = json!({
+    let mut authorisation = make_device_authorisation();
+    let response_body = json!({
         "message": "Internal server error",
         "status": 500,
     });
-    let response = make_json_response(500, resp_body);
+    let response = make_json_response(500, response_body);
 
-    let result = auth.poll_token_response(response).unwrap_err();
+    let result = authorisation.poll_token_response(response).unwrap_err();
 
     match result {
         ApiError::UnexpectedResponse(status, _) => {

--- a/hexpm/src/tests.rs
+++ b/hexpm/src/tests.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2026 The Gleam contributors
 
-use std::{convert::TryFrom, io::Cursor};
+use std::{assert_matches, convert::TryFrom, io::Cursor};
 
 use super::*;
 use serde_json::json;
@@ -228,23 +228,17 @@ fn remove_key_response_success_200() {
 #[test]
 fn remove_docs_response_not_found() {
     let response = make_response(404, vec![]);
-    let result = crate::api_remove_docs_response(response).unwrap_err();
+    let result = crate::api_remove_docs_response(response);
 
-    match result {
-        ApiError::NotFound => (),
-        result => panic!("expected ApiError::NotFound got {result:?}"),
-    }
+    assert_matches!(result, Err(ApiError::NotFound));
 }
 
 #[test]
 fn remove_docs_response_rate_limited() {
     let response = make_response(429, vec![]);
-    let result = crate::api_remove_docs_response(response).unwrap_err();
+    let result = crate::api_remove_docs_response(response);
 
-    match result {
-        ApiError::RateLimited => (),
-        result => panic!("expected ApiError::RateLimited got {result:?}"),
-    }
+    assert_matches!(result, Err(ApiError::RateLimited));
 }
 
 #[test]
@@ -254,12 +248,9 @@ fn remove_docs_response_invalid_key() {
         "status": 401,
     });
     let response = make_json_response(401, response_body);
-    let result = crate::api_remove_docs_response(response).unwrap_err();
+    let result = crate::api_remove_docs_response(response);
 
-    match result {
-        ApiError::InvalidCredentials => (),
-        result => panic!("expected ApiError::InvalidApiKey got {result:?}"),
-    }
+    assert_matches!(result, Err(ApiError::InvalidCredentials));
 }
 
 #[test]
@@ -269,12 +260,9 @@ fn remove_docs_response_forbidden() {
         "status": 403,
     });
     let response = make_json_response(403, response_body);
-    let result = crate::api_remove_docs_response(response).unwrap_err();
+    let result = crate::api_remove_docs_response(response);
 
-    match result {
-        ApiError::Forbidden => (),
-        result => panic!("expected ApiError::Forbidden got {result:?}"),
-    }
+    assert_matches!(result, Err(ApiError::Forbidden));
 }
 
 #[test]
@@ -288,10 +276,13 @@ fn remove_docs_bad_package_name() {
 
     let config = Config::new();
 
-    match crate::api_remove_docs_request(package, version, &key, &config).unwrap_err() {
-        ApiError::InvalidPackageNameFormat(p) if p == package => (),
-        result => panic!("expected Err(ApiError::BadPackage), got {result:?}"),
-    }
+    let result = crate::api_remove_docs_request(package, version, &key, &config);
+
+    assert_matches!(
+        result,
+        Err(ApiError::InvalidPackageNameFormat(error_package))
+        if error_package == package
+    );
 }
 
 #[test]
@@ -330,12 +321,7 @@ fn publish_docs_request() {
 #[test]
 fn publish_docs_response_success() {
     let response = make_response(201, vec![]);
-    let result = crate::api_publish_docs_response(response);
-
-    match result {
-        Ok(()) => (),
-        result => panic!("expected Ok(()), got {result:?}"),
-    }
+    crate::api_publish_docs_response(response).unwrap();
 }
 
 #[test]
@@ -350,10 +336,13 @@ fn publish_docs_bad_package_name() {
 
     let config = Config::new();
 
-    match crate::api_publish_docs_request(package, version, tarball, &key, &config).unwrap_err() {
-        ApiError::InvalidPackageNameFormat(p) if p == package => (),
-        result => panic!("expected Err(ApiError::BadPackage), got {result:?}"),
-    }
+    let result = crate::api_publish_docs_request(package, version, tarball, &key, &config);
+
+    assert_matches!(
+        result,
+        Err(ApiError::InvalidPackageNameFormat(error_package))
+        if error_package == package
+    );
 }
 
 #[test]
@@ -368,10 +357,13 @@ fn publish_docs_bad_package_version() {
 
     let config = Config::new();
 
-    match crate::api_publish_docs_request(package, version, tarball, &key, &config).unwrap_err() {
-        ApiError::InvalidVersionFormat(v) if v == version => (),
-        result => panic!("expected ApiError::BadPackage, got {result:?}"),
-    }
+    let result = crate::api_publish_docs_request(package, version, tarball, &key, &config);
+
+    assert_matches!(
+        result,
+        Err(ApiError::InvalidVersionFormat(error_version))
+        if error_version == version
+    );
 }
 
 #[test]
@@ -379,10 +371,7 @@ fn publish_docs_response_not_found() {
     let response = make_response(404, vec![]);
     let result = crate::api_publish_docs_response(response);
 
-    match result {
-        Err(ApiError::NotFound) => (),
-        result => panic!("expected ApiError::NotFound, got {result:?}"),
-    }
+    assert_matches!(result, Err(ApiError::NotFound));
 }
 
 #[test]
@@ -390,10 +379,7 @@ fn publish_docs_response_rate_limit() {
     let response = make_response(429, vec![]);
     let result = crate::api_publish_docs_response(response);
 
-    match result {
-        Err(ApiError::RateLimited) => (),
-        result => panic!("expected ApiError::RateLimited, got {result:?}"),
-    }
+    assert_matches!(result, Err(ApiError::RateLimited));
 }
 
 #[test]
@@ -405,10 +391,7 @@ fn publish_docs_response_invalid_api_key() {
     let response = make_json_response(401, response_body);
     let result = crate::api_publish_docs_response(response);
 
-    match result {
-        Err(ApiError::InvalidCredentials) => (),
-        result => panic!("expected Err(ApiError::InvalidApiKey), got {result:?}"),
-    }
+    assert_matches!(result, Err(ApiError::InvalidCredentials));
 }
 
 #[test]
@@ -425,10 +408,7 @@ fn publish_docs_response_incorrect_totp_key() {
     );
     let result = crate::api_publish_docs_response(response);
 
-    match result {
-        Err(ApiError::IncorrectOneTimePassword) => (),
-        result => panic!("expected Err(ApiError::IncorrectOneTimePassword), got {result:?}"),
-    }
+    assert_matches!(result, Err(ApiError::IncorrectOneTimePassword));
 }
 
 #[test]
@@ -440,10 +420,7 @@ fn publish_docs_response_forbidden() {
     let response = make_json_response(403, response_body);
     let result = crate::api_publish_docs_response(response);
 
-    match result {
-        Err(ApiError::Forbidden) => (),
-        result => panic!("expected Err(ApiError::Forbidden), got {result:?}"),
-    }
+    assert_matches!(result, Err(ApiError::Forbidden));
 }
 
 fn expected_package_exfmt() -> Package {
@@ -1076,12 +1053,9 @@ fn oauth_device_authorisation_response_default_interval() {
 fn oauth_device_authorisation_response_rate_limited() {
     let client_id = "test-client-id".to_string();
     let response = make_response(429, vec![]);
-    let result = crate::oauth_device_authorisation_response(client_id, response).unwrap_err();
+    let result = crate::oauth_device_authorisation_response(client_id, response);
 
-    match result {
-        ApiError::RateLimited => (),
-        result => panic!("expected RateLimited, got {:?}", result),
-    }
+    assert_matches!(result, Err(ApiError::RateLimited));
 }
 
 #[test]
@@ -1092,14 +1066,15 @@ fn oauth_device_authorisation_response_unexpected_status() {
         "status": 500,
     });
     let response = make_json_response(500, response_body);
-    let result = crate::oauth_device_authorisation_response(client_id, response).unwrap_err();
+    let result = crate::oauth_device_authorisation_response(client_id, response);
 
-    match result {
-        ApiError::UnexpectedResponse(status, _) => {
-            assert_eq!(status, http::StatusCode::INTERNAL_SERVER_ERROR);
-        }
-        result => panic!("expected UnexpectedResponse, got {:?}", result),
-    }
+    assert_matches!(
+        result,
+        Err(ApiError::UnexpectedResponse(
+            http::StatusCode::INTERNAL_SERVER_ERROR,
+            _
+        ))
+    )
 }
 
 fn make_device_authorisation() -> crate::OAuthDeviceAuthorisation {
@@ -1146,15 +1121,16 @@ fn poll_token_response_success() {
     });
     let response = make_json_response(200, response_body);
 
-    let result = authorisation.poll_token_response(response).unwrap();
+    let result = authorisation.poll_token_response(response);
 
-    match result {
-        crate::PollStep::Done(tokens) => {
-            assert_eq!(tokens.access_token, "access-token-abc");
-            assert_eq!(tokens.refresh_token, "refresh-token-xyz");
-        }
-        result => panic!("expected PollStep::Done, got {:?}", result),
-    }
+    assert_matches!(
+        result,
+        Ok(PollStep::Done(OAuthTokens {
+            access_token,
+            refresh_token,
+        }))
+        if access_token == "access-token-abc" && refresh_token == "refresh-token-xyz"
+    );
 }
 
 #[test]
@@ -1165,14 +1141,13 @@ fn poll_token_response_authorization_pending() {
     });
     let response = make_json_response(200, response_body);
 
-    let result = authorisation.poll_token_response(response).unwrap();
+    let result = authorisation.poll_token_response(response);
 
-    match result {
-        crate::PollStep::SleepThenPollAgain(duration) => {
-            assert_eq!(duration, std::time::Duration::from_secs(5));
-        }
-        result => panic!("expected PollStep::SleepThenPollAgain, got {:?}", result),
-    }
+    assert_matches!(
+        result,
+        Ok(PollStep::SleepThenPollAgain(duration))
+        if duration == std::time::Duration::from_secs(5)
+    );
 }
 
 #[test]
@@ -1183,15 +1158,14 @@ fn poll_token_response_slow_down() {
     });
     let response = make_json_response(200, response_body);
 
-    let result = authorisation.poll_token_response(response).unwrap();
+    let result = authorisation.poll_token_response(response);
 
-    match result {
-        crate::PollStep::SleepThenPollAgain(duration) => {
-            // Interval should be doubled from 5 to 10 seconds
-            assert_eq!(duration, std::time::Duration::from_secs(10));
-        }
-        result => panic!("expected PollStep::SleepThenPollAgain, got {:?}", result),
-    }
+    assert_matches!(
+        result,
+        Ok(PollStep::SleepThenPollAgain(duration))
+        // Interval should be doubled from 5 to 10 seconds
+        if duration == std::time::Duration::from_secs(10)
+    );
 }
 
 #[test]
@@ -1203,12 +1177,13 @@ fn poll_token_response_unexpected_status() {
     });
     let response = make_json_response(500, response_body);
 
-    let result = authorisation.poll_token_response(response).unwrap_err();
+    let result = authorisation.poll_token_response(response);
 
-    match result {
-        ApiError::UnexpectedResponse(status, _) => {
-            assert_eq!(status, http::StatusCode::INTERNAL_SERVER_ERROR);
-        }
-        result => panic!("expected UnexpectedResponse, got {:?}", result),
-    }
+    assert_matches!(
+        result,
+        Err(ApiError::UnexpectedResponse(
+            http::StatusCode::INTERNAL_SERVER_ERROR,
+            _
+        ))
+    );
 }

--- a/hexpm/src/version.rs
+++ b/hexpm/src/version.rs
@@ -93,7 +93,7 @@ impl Version {
                 parser
                     .tail()?
                     .into_iter()
-                    .map(|t| t.to_string())
+                    .map(|token| token.to_string())
                     .collect::<Vec<_>>()
                     .join(""),
             ));
@@ -110,7 +110,7 @@ impl Version {
                 parser
                     .tail()?
                     .into_iter()
-                    .map(|t| t.to_string())
+                    .map(|token| token.to_string())
                     .collect::<Vec<_>>()
                     .join(""),
             ));
@@ -143,7 +143,7 @@ impl LowestVersion for pubgrub::Range<Version> {
     fn lowest_version(&self) -> Option<Version> {
         self.iter()
             .flat_map(|(lower, _higher)| match lower {
-                std::ops::Bound::Included(v) => Some(v.clone()),
+                std::ops::Bound::Included(version) => Some(version.clone()),
                 std::ops::Bound::Excluded(_) => None,
                 std::ops::Bound::Unbounded => Some(Version::lowest()),
             })
@@ -211,8 +211,8 @@ impl fmt::Display for Version {
         write!(f, "{}.{}.{}", self.major, self.minor, self.patch)?;
         if !self.pre.is_empty() {
             write!(f, "-")?;
-            for (i, identifier) in self.pre.iter().enumerate() {
-                if i != 0 {
+            for (index, identifier) in self.pre.iter().enumerate() {
+                if index != 0 {
                     write!(f, ".")?;
                 }
                 identifier.fmt(f)?;
@@ -241,12 +241,14 @@ impl fmt::Display for Identifier {
 }
 
 impl Identifier {
-    pub fn concat(self, add_str: &str) -> Identifier {
+    pub fn concat(self, add_string: &str) -> Identifier {
         match self {
-            Identifier::Numeric(n) => Identifier::AlphaNumeric(format!("{n}{add_str}")),
-            Identifier::AlphaNumeric(mut s) => {
-                s.push_str(add_str);
-                Identifier::AlphaNumeric(s)
+            Identifier::Numeric(number) => {
+                Identifier::AlphaNumeric(format!("{number}{add_string}"))
+            }
+            Identifier::AlphaNumeric(mut string) => {
+                string.push_str(add_string);
+                Identifier::AlphaNumeric(string)
             }
         }
     }

--- a/hexpm/src/version/lexer.rs
+++ b/hexpm/src/version/lexer.rs
@@ -12,21 +12,21 @@ use self::Token::*;
 use std::str;
 
 macro_rules! scan_while {
-    ($slf:expr, $start:expr, $first:pat_param $(| $rest:pat)*) => {{
+    ($self:expr, $start:expr, $first:pat_param $(| $rest:pat)*) => {{
         let mut __end = $start;
 
         loop {
-            if let Some((idx, c)) = $slf.one() {
+            if let Some((idx, character)) = $self.one() {
                 __end = idx;
 
-                match c {
-                    $first $(| $rest)* => $slf.step(),
+                match character {
+                    $first $(| $rest)* => $self.step(),
                     _ => break,
                 }
 
                 continue;
             } else {
-                __end = $slf.input.len();
+                __end = $self.input.len();
             }
 
             break;
@@ -63,7 +63,7 @@ pub enum Token<'input> {
     Or,
     /// 'and'
     And,
-    /// any number of whitespace (`\t\r\n `) and its span.
+    /// Any number of whitespace (`\t\r\n `) and its span.
     Whitespace(usize, usize),
     /// Numeric component, like `0` or `42`.
     Numeric(u32),
@@ -100,9 +100,9 @@ impl std::fmt::Display for Token<'_> {
             Or => write!(f, "or"),
             And => write!(f, "and"),
             Whitespace(_, _) => write!(f, " "),
-            Numeric(i) => write!(f, "{i}"),
-            AlphaNumeric(a) => write!(f, "{a}"),
-            LeadingZero(z) => write!(f, "{z}"),
+            Numeric(number) => write!(f, "{number}"),
+            AlphaNumeric(string) => write!(f, "{string}"),
+            LeadingZero(string) => write!(f, "{string}"),
         }
     }
 }
@@ -110,7 +110,7 @@ impl std::fmt::Display for Token<'_> {
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, thiserror::Error)]
 pub enum Error {
     #[error("Unexpected character {0}")]
-    UnexpectedChar(char),
+    UnexpectedCharacter(char),
 }
 
 /// Lexer for semver tokens belonging to a range.
@@ -118,30 +118,30 @@ pub enum Error {
 pub struct Lexer<'input> {
     input: &'input str,
     chars: str::CharIndices<'input>,
-    // lookahead
-    c1: Option<(usize, char)>,
-    c2: Option<(usize, char)>,
+    // Lookahead
+    char0: Option<(usize, char)>,
+    char1: Option<(usize, char)>,
 }
 
 impl<'input> Lexer<'input> {
     /// Construct a new lexer for the given input.
     pub fn new(input: &str) -> Lexer<'_> {
         let mut chars = input.char_indices();
-        let c1 = chars.next();
-        let c2 = chars.next();
+        let char0 = chars.next();
+        let char1 = chars.next();
 
         Lexer {
             input,
             chars,
-            c1,
-            c2,
+            char0,
+            char1,
         }
     }
 
     /// Shift all lookahead storage by one.
     fn step(&mut self) {
-        self.c1 = self.c2;
-        self.c2 = self.chars.next();
+        self.char0 = self.char1;
+        self.char1 = self.chars.next();
     }
 
     fn step_n(&mut self, n: usize) {
@@ -152,13 +152,13 @@ impl<'input> Lexer<'input> {
 
     /// Access the one character, or set it if it is not set.
     fn one(&mut self) -> Option<(usize, char)> {
-        self.c1
+        self.char0
     }
 
     /// Access two characters.
     fn two(&mut self) -> Option<(usize, char, char)> {
-        self.c1
-            .and_then(|(start, c1)| self.c2.map(|(_, c2)| (start, c1, c2)))
+        self.char0
+            .and_then(|(start, char0)| self.char1.map(|(_, char1)| (start, char0, char1)))
     }
 
     /// Consume a component.
@@ -169,18 +169,18 @@ impl<'input> Lexer<'input> {
         let end = scan_while!(self, start, '0'..='9' | 'A'..='Z' | 'a'..='z');
         let input = &self.input[start..end];
 
-        let mut it = input.chars();
-        let (a, b) = (it.next(), it.next());
+        let mut chars = input.chars();
+        let (char0, char1) = (chars.next(), chars.next());
 
-        // exactly zero
-        if a == Some('0') && b.is_none() {
+        // Exactly zero
+        if char0 == Some('0') && char1.is_none() {
             return Ok(Numeric(0));
         }
 
-        if let Ok(numeric) = input.parse::<u32>() {
+        if let Ok(number) = input.parse::<u32>() {
             // Only parse as a number if there is no leading zero
-            if a != Some('0') {
-                return Ok(Numeric(numeric));
+            if char0 != Some('0') {
+                return Ok(Numeric(number));
             } else {
                 return Ok(LeadingZero(input));
             }
@@ -212,9 +212,9 @@ impl<'input> Iterator for Lexer<'input> {
     fn next(&mut self) -> Option<Self::Item> {
         #[allow(clippy::never_loop)]
         loop {
-            // two subsequent char tokens.
-            if let Some((start, a, b)) = self.two() {
-                let two = match (a, b) {
+            // Two subsequent char tokens.
+            if let Some((start, char0, char1)) = self.two() {
+                let double_character_token = match (char0, char1) {
                     ('~', '>') => Some(Pessimistic),
                     ('!', '=') => Some(NotEq),
                     ('<', '=') => Some(LtEq),
@@ -228,15 +228,15 @@ impl<'input> Iterator for Lexer<'input> {
                     _ => None,
                 };
 
-                if let Some(two) = two {
+                if let Some(two) = double_character_token {
                     self.step_n(2);
                     return Some(Ok(two));
                 }
             }
 
-            // single char and start of numeric tokens.
-            if let Some((start, c)) = self.one() {
-                let tok = match c {
+            // Single char and start of numeric tokens.
+            if let Some((start, char2)) = self.one() {
+                let token = match char2 {
                     ' ' | '\t' | '\n' | '\r' => {
                         self.step();
                         return Some(self.whitespace(start));
@@ -250,11 +250,11 @@ impl<'input> Iterator for Lexer<'input> {
                         self.step();
                         return Some(self.component(start));
                     }
-                    c => return Some(Err(UnexpectedChar(c))),
+                    character => return Some(Err(UnexpectedCharacter(character))),
                 };
 
                 self.step();
-                return Some(Ok(tok));
+                return Some(Ok(token));
             };
 
             return None;

--- a/hexpm/src/version/parser.rs
+++ b/hexpm/src/version/parser.rs
@@ -60,7 +60,7 @@ impl fmt::Display for Error {
     }
 }
 
-/// impl for backwards compatibility.
+/// Implementation for backwards compatibility.
 impl From<Error> for String {
     fn from(value: Error) -> Self {
         value.to_string()
@@ -72,7 +72,7 @@ pub struct Parser<'input> {
     /// Source of token.
     lexer: Lexer<'input>,
     /// Lookaehead.
-    c1: Option<Token<'input>>,
+    token0: Option<Token<'input>>,
 }
 
 impl<'input> Parser<'input> {
@@ -80,31 +80,31 @@ impl<'input> Parser<'input> {
     pub fn new(input: &'input str) -> Result<Parser<'input>, Error> {
         let mut lexer = Lexer::new(input);
 
-        let c1 = if let Some(c1) = lexer.next() {
-            Some(c1?)
+        let token0 = if let Some(token0) = lexer.next() {
+            Some(token0?)
         } else {
             None
         };
 
-        Ok(Parser { lexer, c1 })
+        Ok(Parser { lexer, token0 })
     }
 
     /// Pop one token.
     #[inline(always)]
     fn pop(&mut self) -> Result<Token<'input>, Error> {
-        let c1 = if let Some(c1) = self.lexer.next() {
-            Some(c1?)
+        let token0 = if let Some(token0) = self.lexer.next() {
+            Some(token0?)
         } else {
             None
         };
 
-        mem::replace(&mut self.c1, c1).ok_or(UnexpectedEnd)
+        mem::replace(&mut self.token0, token0).ok_or(UnexpectedEnd)
     }
 
     /// Peek one token.
     #[inline(always)]
     fn peek(&mut self) -> Option<&Token<'input>> {
-        self.c1.as_ref()
+        self.token0.as_ref()
     }
 
     /// Skip whitespace if present.
@@ -153,14 +153,14 @@ impl<'input> Parser<'input> {
                 // TODO: Borrow?
                 Identifier::AlphaNumeric(identifier.to_string())
             }
-            Token::Numeric(n) => Identifier::Numeric(n),
-            tok => return Err(UnexpectedToken(tok.to_string())),
+            Token::Numeric(number) => Identifier::Numeric(number),
+            token => return Err(UnexpectedToken(token.to_string())),
         };
 
         if let Some(&Token::Hyphen) = self.peek() {
-            // pop the peeked hyphen
+            // Pop the peeked hyphen
             self.pop()?;
-            // concat with any following identifiers
+            // Concat with any following identifiers
             Ok(identifier
                 .concat("-")
                 .concat(&self.identifier()?.to_string()))
@@ -178,7 +178,7 @@ impl<'input> Parser<'input> {
             _ => return Ok(vec![]),
         }
 
-        // pop the peeked hyphen.
+        // Pop the peeked hyphen.
         self.pop()?;
         self.parts()
     }
@@ -212,9 +212,9 @@ impl<'input> Parser<'input> {
         loop {
             match self.pop() {
                 Err(UnexpectedEnd) => break,
-                Ok(Token::LeadingZero(s)) => buffer.push_str(s),
-                Ok(Token::AlphaNumeric(s)) => buffer.push_str(s),
-                Ok(Token::Numeric(s)) => buffer.push_str(&s.to_string()),
+                Ok(Token::LeadingZero(string)) => buffer.push_str(string),
+                Ok(Token::AlphaNumeric(string)) => buffer.push_str(string),
+                Ok(Token::Numeric(number)) => buffer.push_str(&number.to_string()),
                 Ok(Token::Dot) => buffer.push('.'),
                 Ok(token) => return Err(UnexpectedToken(token.to_string())),
                 Err(error) => return Err(error),
@@ -390,23 +390,23 @@ impl<'input> Parser<'input> {
 
     /// Check if we have reached the end of input.
     pub fn is_eof(&mut self) -> bool {
-        self.c1.is_none()
+        self.token0.is_none()
     }
 
     /// Get the rest of the tokens in the parser.
     ///
     /// Useful for debugging.
     pub fn tail(&mut self) -> Result<Vec<Token<'input>>, Error> {
-        let mut out = Vec::new();
+        let mut output = Vec::new();
 
-        if let Some(t) = self.c1.take() {
-            out.push(t);
+        if let Some(token) = self.token0.take() {
+            output.push(token);
         }
 
-        for t in self.lexer.by_ref() {
-            out.push(t?);
+        for token in self.lexer.by_ref() {
+            output.push(token?);
         }
 
-        Ok(out)
+        Ok(output)
     }
 }


### PR DESCRIPTION
Here, I removed abbreviations from the `hexpm` crate, removed one redundant clone, simplified one function, and replaced long matches with `assert_matches!` in tests.
***
- [ ] The changes in this PR have been discussed beforehand in an issue
- [ ] The issue for this PR has been linked
- [ ] Tests have been added for new behaviour
- [ ] The changelog has been updated for any user-facing changes
