### PR TITLE
Fix JavaScript names escaping a case clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,6 +212,12 @@
   runtime crash when the shadowed name was a module function or constant.
   ([John Downey](https://github.com/jtdowney))
 
+- Fixed a bug where on the JavaScript target the variables a clause guard
+  needed would be declared in the enclosing scope of a case that always
+  matched, so a later `let` binding one of those names produced a duplicate
+  declaration and the whole module failed to parse.
+  ([John Downey](https://github.com/jtdowney))
+
 ## v1.18.1 - 2026-08-01
 
 - Fixed a bug where the Erlang code generator would generate wrong code when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,12 @@
   prefix alias.
   ([Andrey Kozhev](https://github.com/ankddev))
 
+- Fixed a bug where on the JavaScript target a name shadowed inside a case
+  clause that always matched would be used in place of the outer binding by the
+  code that followed the case expression. This could produce a wrong value, or a
+  runtime crash when the shadowed name was a module function or constant.
+  ([John Downey](https://github.com/jtdowney))
+
 ## v1.18.1 - 2026-08-01
 
 - Fixed a bug where the Erlang code generator would generate wrong code when

--- a/compiler-core/src/javascript/decision.rs
+++ b/compiler-core/src/javascript/decision.rs
@@ -919,9 +919,11 @@ impl<'a, 'doc> CasePrinter<'_, '_, 'a, '_, 'doc> {
             .iter()
             .partition(|(variable, _)| guard_variables.contains(variable));
 
-        let (check_bindings, check, if_true) = self.inside_new_scope(|this| {
+        let (check_bindings, check, if_true) = self.inside_enclosing_scope(|this| {
             // check_bindings and if_true generation have to be in this scope so that pattern-bound
             // variables used in guards don't leak into other case branches (if_false).
+            // The check bindings are emitted before the `if`, so they end up in
+            // the enclosing scope and their names have to stay reserved there.
             let check_bindings = this.variables.bindings_ref_doc(arena, &check_bindings);
             let check = this.variables.expression_generator.guard(arena, guard);
             // All the other bindings that are not needed by the guard check will

--- a/compiler-core/src/javascript/decision.rs
+++ b/compiler-core/src/javascript/decision.rs
@@ -86,7 +86,9 @@ pub fn case<'a, 'doc>(
         tree @ (Decision::Run { .. }
         | Decision::Guard { .. }
         | Decision::Switch { .. }
-        | Decision::Fail) => printer.decision(arena, tree).into_doc(arena),
+        | Decision::Fail) => printer
+            .inside_enclosing_scope(|this| this.decision(arena, tree))
+            .into_doc(arena),
     };
     docvec![
         arena,
@@ -567,49 +569,10 @@ impl<'a, 'doc> CasePrinter<'_, '_, 'a, '_, 'doc> {
                 self.variables.record_check_assignments(arena, var, check);
             }
 
-            // We can't use `inside_new_scope` here without care: the
-            // code we generate goes directly into the enclosing scope
-            // (there's no wrapping if-else block). User variables bound
-            // in the branch go out of scope at its end, so their counters
-            // are reset and later references resolve to the outer bindings.
-            // Compiler synthesised variables (the `$` case subjects, `_pipe`,
-            // `_block`, ...) can't be referenced by user code and their
-            // declarations leak into this scope. Restoring only the user-variable
-            // counters leaves the synthesised counters advanced, so later code
-            // can't redeclare one of them.
-            let old_user_variables = match &self.kind {
-                DecisionKind::Case { .. } => self
-                    .variables
-                    .expression_generator
-                    .current_scope
-                    .user_variables()
-                    .clone(),
-                DecisionKind::LetAssert { .. } => im::HashMap::new(),
-            };
-            let old_names = self.variables.scoped_variable_names.clone();
-            let old_segments = self.variables.segment_values.clone();
-            let old_segment_names = self.variables.scoped_segment_names.clone();
-
-            let result = self.decision(arena, fallback);
-
-            match &self.kind {
-                DecisionKind::Case { .. } => {
-                    // Restore the user variables that were in scope before the
-                    // branch. The synthesised counters are left advanced, and
-                    // the high-water marks keep any user variable that leaked
-                    // out of the branch from being redeclared by a later `let`.
-                    self.variables
-                        .expression_generator
-                        .current_scope
-                        .restore_user_variables(&old_user_variables);
-                }
-                DecisionKind::LetAssert { .. } => {}
-            }
-
-            self.variables.scoped_variable_names = old_names;
-            self.variables.segment_values = old_segments;
-            self.variables.scoped_segment_names = old_segment_names;
-            return result;
+            // We can't use `inside_new_scope` here: the code we generate goes
+            // directly into the enclosing scope, there's no wrapping if-else
+            // block to contain it.
+            return self.inside_enclosing_scope(|this| this.decision(arena, fallback));
         }
 
         // Otherwise we'll have to generate a series of if-else to check which
@@ -852,6 +815,52 @@ impl<'a, 'doc> CasePrinter<'_, '_, 'a, '_, 'doc> {
                 document.into_doc(arena),
             ))
         }
+    }
+
+    /// Generate code that goes directly into the enclosing JavaScript scope,
+    /// with no wrapping if-else block to contain it, then put back the user
+    /// variables that were in scope beforehand.
+    ///
+    /// User variables bound in the branch go out of scope at its end, so their
+    /// counters are reset and later references resolve to the outer bindings.
+    /// Compiler synthesised variables (the `$` case subjects, `_pipe`,
+    /// `_block`, ...) can't be referenced by user code and their declarations
+    /// leak into this scope. Restoring only the user-variable counters leaves
+    /// the synthesised counters advanced, so later code can't redeclare one of
+    /// them, and the high-water marks keep any user variable that leaked out of
+    /// the branch from being redeclared by a later `let`.
+    fn inside_enclosing_scope<A, F>(&mut self, run: F) -> A
+    where
+        F: Fn(&mut Self) -> A,
+    {
+        let old_user_variables = match &self.kind {
+            DecisionKind::Case { .. } => self
+                .variables
+                .expression_generator
+                .current_scope
+                .user_variables()
+                .clone(),
+            DecisionKind::LetAssert { .. } => im::HashMap::new(),
+        };
+        let old_names = self.variables.scoped_variable_names.clone();
+        let old_segments = self.variables.segment_values.clone();
+        let old_segment_names = self.variables.scoped_segment_names.clone();
+
+        let output = run(self);
+
+        match &self.kind {
+            DecisionKind::Case { .. } => self
+                .variables
+                .expression_generator
+                .current_scope
+                .restore_user_variables(&old_user_variables),
+            DecisionKind::LetAssert { .. } => {}
+        }
+
+        self.variables.scoped_variable_names = old_names;
+        self.variables.segment_values = old_segments;
+        self.variables.scoped_segment_names = old_segment_names;
+        output
     }
 
     fn inside_new_scope<A, F>(&mut self, run: F) -> A

--- a/compiler-core/src/javascript/tests/case.rs
+++ b/compiler-core/src/javascript/tests/case.rs
@@ -1175,3 +1175,41 @@ pub fn go(x) {
 "
     );
 }
+
+// https://github.com/gleam-lang/gleam/issues/6213
+#[test]
+fn shadowing_in_directly_matching_case_does_not_leak_out() {
+    assert_js!(
+        r#"
+pub fn go() {
+  let m = 1
+  let _ = case 0 + 0 {
+    _ -> {
+      let m = 99
+      m
+    }
+  }
+  m
+}"#
+    )
+}
+
+// https://github.com/gleam-lang/gleam/issues/6212
+#[test]
+fn pattern_shadowing_module_function_in_directly_matching_case() {
+    assert_js!(
+        r#"
+fn wibble(_: Int) -> Float {
+  0.0
+}
+
+pub fn go() {
+  case 0 + 0 {
+    wibble -> {
+      echo wibble
+    }
+  }
+  |> wibble
+}"#
+    )
+}

--- a/compiler-core/src/javascript/tests/case.rs
+++ b/compiler-core/src/javascript/tests/case.rs
@@ -1213,3 +1213,18 @@ pub fn go() {
 }"#
     )
 }
+
+#[test]
+fn guard_binding_in_directly_matching_case_is_not_redeclared() {
+    assert_js!(
+        r#"
+pub fn go(x) {
+  case x {
+    #(_, b) if b == 2 -> b
+    #(_, b) -> b
+  }
+  let b = 5
+  b
+}"#
+    )
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__guard_binding_in_directly_matching_case_is_not_redeclared.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__guard_binding_in_directly_matching_case_is_not_redeclared.snap
@@ -1,0 +1,27 @@
+---
+source: compiler-core/src/javascript/tests/case.rs
+expression: "\npub fn go(x) {\n  case x {\n    #(_, b) if b == 2 -> b\n    #(_, b) -> b\n  }\n  let b = 5\n  b\n}"
+---
+----- SOURCE CODE
+
+pub fn go(x) {
+  case x {
+    #(_, b) if b == 2 -> b
+    #(_, b) -> b
+  }
+  let b = 5
+  b
+}
+
+----- COMPILED JAVASCRIPT
+export function go(x) {
+  let b = x[1];
+  if (b === 2) {
+    b;
+  } else {
+    let b = x[1];
+    b;
+  }
+  let b = 5;
+  return b;
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__guard_binding_in_directly_matching_case_is_not_redeclared.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__guard_binding_in_directly_matching_case_is_not_redeclared.snap
@@ -19,9 +19,9 @@ export function go(x) {
   if (b === 2) {
     b;
   } else {
-    let b = x[1];
-    b;
+    let b$1 = x[1];
+    b$1;
   }
-  let b = 5;
-  return b;
+  let b$1 = 5;
+  return b$1;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__guard_variable_only_brought_into_scope_when_needed_1.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__guard_variable_only_brought_into_scope_when_needed_1.snap
@@ -20,8 +20,8 @@ export function main() {
   if (i === 1) {
     return true;
   } else {
-    let i = $;
-    if (i < 2) {
+    let i$1 = $;
+    if (i$1 < 2) {
       return true;
     } else {
       return false;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__list_with_guard.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__list_with_guard.snap
@@ -24,8 +24,8 @@ export function go(x) {
     if (first < 10) {
       return first * 2;
     } else {
-      let first = x.head;
-      return first;
+      let first$1 = x.head;
+      return first$1;
     }
   }
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__list_with_guard_no_binding.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__list_with_guard_no_binding.snap
@@ -23,7 +23,7 @@ export function go(x) {
     let first = x.head;
     return first * 2;
   } else {
-    let first = x.head;
-    return first;
+    let first$1 = x.head;
+    return first$1;
   }
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__pattern_shadowing_module_function_in_directly_matching_case.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__pattern_shadowing_module_function_in_directly_matching_case.snap
@@ -1,0 +1,46 @@
+---
+source: compiler-core/src/javascript/tests/case.rs
+expression: "\nfn wibble(_: Int) -> Float {\n  0.0\n}\n\npub fn go() {\n  case 0 + 0 {\n    wibble -> {\n      echo wibble\n    }\n  }\n  |> wibble\n}"
+---
+----- SOURCE CODE
+
+fn wibble(_: Int) -> Float {
+  0.0
+}
+
+pub fn go() {
+  case 0 + 0 {
+    wibble -> {
+      echo wibble
+    }
+  }
+  |> wibble
+}
+
+----- COMPILED JAVASCRIPT
+import * as $stdlib$dict from "../../gleam_stdlib/gleam/dict.mjs";
+import {
+  Empty as $Empty,
+  NonEmpty as $NonEmpty,
+  CustomType as $CustomType,
+  bitArraySlice,
+  bitArraySliceToInt,
+  BitArray as $BitArray,
+  List as $List,
+  UtfCodepoint as $UtfCodepoint,
+} from "../gleam.mjs";
+
+function wibble(_) {
+  return 0.0;
+}
+
+export function go() {
+  let _block;
+  let $ = 0 + 0;
+  let wibble$1 = $;
+  _block = echo(wibble$1, undefined, "src/module.gleam", 9);
+  let _pipe = _block;
+  return wibble$1(_pipe);
+}
+
+// ...omitted code from `templates/echo.mjs`...

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__pattern_shadowing_module_function_in_directly_matching_case.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__pattern_shadowing_module_function_in_directly_matching_case.snap
@@ -40,7 +40,7 @@ export function go() {
   let wibble$1 = $;
   _block = echo(wibble$1, undefined, "src/module.gleam", 9);
   let _pipe = _block;
-  return wibble$1(_pipe);
+  return wibble(_pipe);
 }
 
 // ...omitted code from `templates/echo.mjs`...

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__shadowing_in_directly_matching_case_does_not_leak_out.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__shadowing_in_directly_matching_case_does_not_leak_out.snap
@@ -24,5 +24,5 @@ export function go() {
   _block = m$1;
   let $ = _block;
   
-  return m$1;
+  return m;
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__shadowing_in_directly_matching_case_does_not_leak_out.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__shadowing_in_directly_matching_case_does_not_leak_out.snap
@@ -1,0 +1,28 @@
+---
+source: compiler-core/src/javascript/tests/case.rs
+expression: "\npub fn go() {\n  let m = 1\n  let _ = case 0 + 0 {\n    _ -> {\n      let m = 99\n      m\n    }\n  }\n  m\n}"
+---
+----- SOURCE CODE
+
+pub fn go() {
+  let m = 1
+  let _ = case 0 + 0 {
+    _ -> {
+      let m = 99
+      m
+    }
+  }
+  m
+}
+
+----- COMPILED JAVASCRIPT
+export function go() {
+  let m = 1;
+  let _block;
+  let $1 = 0 + 0;
+  let m$1 = 99;
+  _block = m$1;
+  let $ = _block;
+  
+  return m$1;
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__strings__string_prefix_guard_on_bound_variable_falls_through.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__strings__string_prefix_guard_on_bound_variable_falls_through.snap
@@ -20,8 +20,8 @@ export function classify(input) {
     if (rest === "x") {
       return "aa-x";
     } else {
-      let rest = input.slice(1);
-      return rest;
+      let rest$1 = input.slice(1);
+      return rest$1;
     }
   } else if (input.charCodeAt(0) === 97) {
     let rest = input.slice(1);

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__strings__string_prefix_multibyte_falls_through_to_shorter.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__strings__string_prefix_multibyte_falls_through_to_shorter.snap
@@ -20,8 +20,8 @@ export function classify(input) {
     if (rest === "x") {
       return rest;
     } else {
-      let rest = input.slice(2);
-      return rest;
+      let rest$1 = input.slice(2);
+      return rest$1;
     }
   } else if (input.startsWith("🫥")) {
     let rest = input.slice(2);

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__strings__string_prefix_name_binding_falls_through_to_shorter.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__strings__string_prefix_name_binding_falls_through_to_shorter.snap
@@ -21,8 +21,8 @@ export function classify(input) {
       return rest;
     } else {
       let first = "a";
-      let rest = input.slice(1);
-      return rest + first;
+      let rest$1 = input.slice(1);
+      return rest$1 + first;
     }
   } else if (input.charCodeAt(0) === 97) {
     let first = "a";

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__strings__string_prefix_nested_guard_falls_through_to_shorter.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__strings__string_prefix_nested_guard_falls_through_to_shorter.snap
@@ -26,8 +26,8 @@ export function classify(input, flag) {
         if (rest === "x") {
           return rest;
         } else {
-          let rest = $.slice(2);
-          return rest;
+          let rest$1 = $.slice(2);
+          return rest$1;
         }
       } else if ($.startsWith("ib")) {
         let rest = $.slice(2);

--- a/test/language/test/language/clause_guard_test.gleam
+++ b/test/language/test/language/clause_guard_test.gleam
@@ -595,3 +595,13 @@ pub fn or_guard_does_not_escape_its_pattern_test() {
       _ -> 0
     }
 }
+
+pub fn guard_binding_in_directly_matching_case_is_not_redeclared_test() {
+  let value = make_pair(1, 2)
+  case value {
+    #(_, b) if b == 2 -> b
+    #(_, b) -> b
+  }
+  let b = 5
+  assert b == 5
+}

--- a/test/language/test/language/directly_matching_case_subject_test.gleam
+++ b/test/language/test/language/directly_matching_case_subject_test.gleam
@@ -13,6 +13,10 @@ fn add_two(x: Int) -> Int {
   x + 2
 }
 
+fn wibble(_: Int) -> Float {
+  0.0
+}
+
 // github.com/gleam-lang/gleam/issues/5265
 pub fn directly_matching_case_subject_test() {
   let result = {
@@ -89,4 +93,31 @@ pub fn no_duplicate_let_when_rebinding_variable_after_directly_matching_case_tes
     n
   }
   assert result == 6
+}
+
+// https://github.com/gleam-lang/gleam/issues/6213
+pub fn shadowing_in_directly_matching_case_does_not_leak_out_test() {
+  let result = {
+    let m = 1
+    let _ = case 0 + 0 {
+      _ -> {
+        let m = 99
+        m
+      }
+    }
+    m
+  }
+
+  assert result == 1
+}
+
+// https://github.com/gleam-lang/gleam/issues/6212
+pub fn pattern_shadowing_module_function_in_directly_matching_case_test() {
+  let result =
+    case 0 + 0 {
+      wibble -> wibble
+    }
+    |> wibble
+
+  assert result == 0.0
 }


### PR DESCRIPTION
Closes #6212
Closes #6213

This is related to #5743 in that it is from when decision trees can be embedded into the parent scope without any if/else branches which create new scope for JS. I took the code largely introduced in #5746 and applied it for this case too.

Since this had popped up a few times I also went and looked for other cases and found one relating to guards. Bindings for guards are declared in outer scope.

For example, this is a problem because `b` gets declared twice:

```
----- SOURCE CODE

pub fn go(x) {
  case x {
    #(_, b) if b == 2 -> b
    #(_, b) -> b
  }
  let b = 5
  b
}

----- COMPILED JAVASCRIPT
export function go(x) {
  let b = x[1];
  if (b === 2) {
    b;
  } else {
    let b = x[1];
    b;
  }
  let b = 5;
  return b;
}
```

- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes
