### PR TITLE
Sort JS variant constant imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,12 @@
   ([Amr Kadry](https://github.com/Amrkadry) and
   ([Louis Pilfold](https://github.com/lpil))
 
+- The ordering of import statements in generated JavaScript code is now stable.
+  Previously the same code compiled twice could produce different output, as
+  the singleton constants imported for a type's fieldless variants were emitted
+  in a different order on each run.
+  ([John Downey](https://github.com/jtdowney))
+
 - Make links to Tangled repositories use their new domain & URL format.
   ([Naomi Roberts](https://github.com/naomieow))
 
@@ -245,11 +251,6 @@
 - Fixed a bug where a package's optional dependency requirements could be
   ignored, or could pull a package into the dependency tree that nothing
   actually required.
-  ([John Downey](https://github.com/jtdowney))
-
-- Fixed a bug where on the JavaScript target compiling the same code twice
-  could produce different output, as the singleton constants imported for a
-  type's fieldless variants were emitted in a different order on each run.
   ([John Downey](https://github.com/jtdowney))
 
 ## v1.18.1 - 2026-08-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -247,6 +247,11 @@
   actually required.
   ([John Downey](https://github.com/jtdowney))
 
+- Fixed a bug where on the JavaScript target compiling the same code twice
+  could produce different output, as the singleton constants imported for a
+  type's fieldless variants were emitted in a different order on each run.
+  ([John Downey](https://github.com/jtdowney))
+
 ## v1.18.1 - 2026-08-01
 
 - Fixed a bug where the Erlang code generator would generate wrong code when

--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -321,7 +321,12 @@ impl<'a, 'doc> Generator<'a> {
             self.register_prelude_usage(arena, &mut imports, "sizedFloat", None);
         }
 
-        for (variant, alias) in self.tracker.variant_constants_used.iter() {
+        // Sorted so that the imports we generate are the same on every
+        // compilation.
+        let mut variant_constants: Vec<_> = self.tracker.variant_constants_used.iter().collect();
+        variant_constants.sort();
+
+        for (variant, alias) in variant_constants {
             let path = self.import_path(&variant.package, &variant.module);
             let member = Member {
                 name: eco_format!("{}${}$const", variant.type_name, variant.name),
@@ -1599,7 +1604,7 @@ pub(crate) struct UsageTracker {
     pub variants_used_in_instanceof: HashSet<TypeVariant>,
 }
 
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct TypeVariant {
     package: EcoString,
     module: EcoString,

--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -323,8 +323,7 @@ impl<'a, 'doc> Generator<'a> {
 
         // Sorted so that the imports we generate are the same on every
         // compilation.
-        let mut variant_constants: Vec<_> = self.tracker.variant_constants_used.iter().collect();
-        variant_constants.sort();
+        let variant_constants = self.tracker.variant_constants_used.iter().sorted();
 
         for (variant, alias) in variant_constants {
             let path = self.import_path(&variant.package, &variant.module);

--- a/compiler-core/src/javascript/tests/custom_types.rs
+++ b/compiler-core/src/javascript/tests/custom_types.rs
@@ -1091,6 +1091,23 @@ pub fn main() {
 }
 
 #[test]
+fn singletons_for_multiple_variants_from_one_module_are_imported_in_a_stable_order() {
+    assert_js!(
+        (
+            "colour",
+            "pub type Colour { Red Orange Yellow Green Blue Violet }"
+        ),
+        "
+import colour.{Blue, Green, Orange, Red, Violet, Yellow}
+
+pub fn main() {
+  #(Red, Orange, Yellow, Green, Blue, Violet)
+}
+"
+    );
+}
+
+#[test]
 fn fieldless_variant_still_imported_if_used_in_instanceof_comparison() {
     assert_js!(
         ("wibble", "pub type Wibble { Wibble Wobble }"),

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__singletons_for_multiple_variants_from_one_module_are_imported_in_a_stable_order.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__custom_types__singletons_for_multiple_variants_from_one_module_are_imported_in_a_stable_order.snap
@@ -1,0 +1,38 @@
+---
+source: compiler-core/src/javascript/tests/custom_types.rs
+expression: "\nimport colour.{Blue, Green, Orange, Red, Violet, Yellow}\n\npub fn main() {\n  #(Red, Orange, Yellow, Green, Blue, Violet)\n}\n"
+---
+----- SOURCE CODE
+-- colour.gleam
+pub type Colour { Red Orange Yellow Green Blue Violet }
+
+-- main.gleam
+
+import colour.{Blue, Green, Orange, Red, Violet, Yellow}
+
+pub fn main() {
+  #(Red, Orange, Yellow, Green, Blue, Violet)
+}
+
+
+----- COMPILED JAVASCRIPT
+import * as $colour from "../colour.mjs";
+import {
+  Colour$Blue$const,
+  Colour$Green$const,
+  Colour$Orange$const,
+  Colour$Red$const,
+  Colour$Violet$const,
+  Colour$Yellow$const,
+} from "../colour.mjs";
+
+export function main() {
+  return [
+    Colour$Red$const,
+    Colour$Orange$const,
+    Colour$Yellow$const,
+    Colour$Green$const,
+    Colour$Blue$const,
+    Colour$Violet$const,
+  ];
+}


### PR DESCRIPTION
This was discussed on Discord a few weeks ago, but I forgot to make a PR until now. In a few of the investigations around decision trees, I have been trying to validate that things end up with the same SHA256 hash at the end of compilation, and I noticed that on some projects, files were inconsistent not because the decision tree created different code, but because the import paths were randomized by the hash map iteration. Not sure this really qualifies as a "bug" so much as a best practice to generate consistent code.

- [ ] The changes in this PR have been discussed beforehand in an issue
- [ ] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes
