### PR TITLE
I forgot about qualified values

### DIFF
--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -2795,7 +2795,13 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
             builder.bit_array_segment(segment.location());
             self.constant(builder, segment);
             builder.bit_array_segment_default_size();
-            builder.bit_array_segment_specifiers([BitArraySegmentSpecifier::Utf8]);
+            builder.bit_array_segment_specifiers([
+                if self.constant_produces_literal_string(segment) {
+                    BitArraySegmentSpecifier::Utf8
+                } else {
+                    BitArraySegmentSpecifier::Binary
+                },
+            ]);
         }
         builder.end_bit_array(bit_array);
     }
@@ -2827,7 +2833,7 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
         builder.bit_array_segment(value.location());
         self.maybe_block_expr(builder, value);
         builder.bit_array_segment_default_size();
-        builder.bit_array_segment_specifiers(if produces_literal_string(value) {
+        builder.bit_array_segment_specifiers(if self.produces_literal_string(value) {
             [BitArraySegmentSpecifier::Utf8]
         } else {
             [BitArraySegmentSpecifier::Binary]
@@ -3097,7 +3103,7 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
         //   ```
         //
         if segment.type_.is_string()
-            && !produces_literal_string(&segment.value)
+            && !self.produces_literal_string(&segment.value)
             && let Some(encoding) = expression_segment_string_encoding(segment)
         {
             let (size, endiannes) = match encoding {
@@ -3354,7 +3360,7 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
         builder.bit_array_segment(guard.location());
         self.clause_guard(builder, guard, assignments);
         builder.bit_array_segment_default_size();
-        builder.bit_array_segment_specifiers(if guard_produces_literal_string(guard) {
+        builder.bit_array_segment_specifiers(if self.guard_produces_literal_string(guard) {
             [BitArraySegmentSpecifier::Utf8]
         } else {
             [BitArraySegmentSpecifier::Binary]
@@ -3492,6 +3498,121 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
                 escape_erlang_existing_name(name),
             );
             builder.end_call(call);
+        }
+    }
+
+    /// This returns true if the given expression is going to be compiled to a
+    /// single literal Erlang string.
+    /// This is not only true for literal Gleam strings like `"abc"`, but also for
+    /// variables referencing string constants (as those are inlined)
+    fn produces_literal_string(&self, value: &TypedExpr) -> bool {
+        match value {
+            TypedExpr::String { .. } => true,
+
+            TypedExpr::Var {
+                constructor:
+                    ValueConstructor {
+                        variant:
+                            ValueConstructorVariant::ModuleConstant {
+                                literal, module, ..
+                            },
+                        ..
+                    },
+                ..
+            } => {
+                // Only constants from the same module are inlined (and so can
+                // produce a literal string if they reference one).
+                // Remote constants are never inlined and so produce no literal
+                // string.
+                *module == self.module_generator.module.name
+                    && self.constant_produces_literal_string(literal)
+            }
+
+            TypedExpr::Int { .. }
+            | TypedExpr::Var { .. }
+            | TypedExpr::Float { .. }
+            | TypedExpr::Block { .. }
+            | TypedExpr::Pipeline { .. }
+            | TypedExpr::Fn { .. }
+            | TypedExpr::List { .. }
+            | TypedExpr::Call { .. }
+            | TypedExpr::BinOp { .. }
+            | TypedExpr::Case { .. }
+            | TypedExpr::RecordAccess { .. }
+            | TypedExpr::PositionalAccess { .. }
+            | TypedExpr::ModuleSelect { .. }
+            | TypedExpr::Tuple { .. }
+            | TypedExpr::TupleIndex { .. }
+            | TypedExpr::Todo { .. }
+            | TypedExpr::Panic { .. }
+            | TypedExpr::Echo { .. }
+            | TypedExpr::BitArray { .. }
+            | TypedExpr::RecordUpdate { .. }
+            | TypedExpr::NegateBool { .. }
+            | TypedExpr::NegateInt { .. }
+            | TypedExpr::Invalid { .. } => false,
+        }
+    }
+
+    /// This returns true if the given constant is going to be compiled to a
+    /// single literal Erlang string.
+    /// This is not only true for literal Gleam strings like `"abc"`, but also for
+    /// variables referencing string constants (as those are inlined)
+    fn constant_produces_literal_string(&self, constant: &Constant<Arc<Type>>) -> bool {
+        match constant {
+            Constant::String { .. } => true,
+
+            Constant::Var {
+                constructor: Some(constructor),
+                ..
+            } if let ValueConstructor {
+                variant:
+                    ValueConstructorVariant::ModuleConstant {
+                        literal, module, ..
+                    },
+                ..
+            } = constructor.as_ref() =>
+            {
+                // Only constants from the same module are inlined (and so can
+                // produce a literal string if they reference one).
+                // Remote constants are never inlined and so produce no literal
+                // string.
+                *module == self.module_generator.module.name
+                    && self.constant_produces_literal_string(literal)
+            }
+
+            Constant::Int { .. }
+            | Constant::Float { .. }
+            | Constant::Tuple { .. }
+            | Constant::List { .. }
+            | Constant::Record { .. }
+            | Constant::RecordUpdate { .. }
+            | Constant::BitArray { .. }
+            | Constant::BinaryOperator { .. }
+            | Constant::Invalid { .. }
+            | Constant::Todo { .. }
+            | Constant::Var { .. } => false,
+        }
+    }
+
+    /// This returns true if the given guard is going to be compiled to a
+    /// single literal Erlang string.
+    /// This is not only true for literal Gleam strings like `"abc"`, but also for
+    /// variables referencing string constants (as those are inlined)
+    fn guard_produces_literal_string(&self, guard: &ClauseGuard<Arc<Type>>) -> bool {
+        match guard {
+            ClauseGuard::Block { value, .. } => self.guard_produces_literal_string(value),
+
+            ClauseGuard::Constant(constant) => self.constant_produces_literal_string(constant),
+
+            ClauseGuard::BinaryOperator { .. }
+            | ClauseGuard::ModuleSelect { .. }
+            | ClauseGuard::Not { .. }
+            | ClauseGuard::LocalVariable { .. }
+            | ClauseGuard::TupleIndex { .. }
+            | ClauseGuard::FieldAccess { .. }
+            | ClauseGuard::UnqualifiedRemoteConstant { .. }
+            | ClauseGuard::Invalid { .. } => false,
         }
     }
 }
@@ -3789,103 +3910,6 @@ fn type_export(custom_type: &TypedCustomType) -> (EcoString, usize) {
     let name = erl_safe_type_name(to_snake_case(&custom_type.name));
     let arity = custom_type.typed_parameters.len();
     (name, arity)
-}
-
-/// This returns true if the given expression is going to be compiled to a
-/// single literal Erlang string.
-/// This is not only true for literal Gleam strings like `"abc"`, but also for
-/// variables referencing string constants (as those are inlined)
-fn produces_literal_string(value: &TypedExpr) -> bool {
-    match value {
-        TypedExpr::String { .. } => true,
-
-        // Constants are inlined on the Erlang target, so we need to check if
-        // those produce literal strings too!
-        TypedExpr::Var {
-            constructor:
-                ValueConstructor {
-                    variant: ValueConstructorVariant::ModuleConstant { literal, .. },
-                    ..
-                },
-            ..
-        } => constant_produces_literal_string(literal),
-
-        TypedExpr::Int { .. }
-        | TypedExpr::Var { .. }
-        | TypedExpr::Float { .. }
-        | TypedExpr::Block { .. }
-        | TypedExpr::Pipeline { .. }
-        | TypedExpr::Fn { .. }
-        | TypedExpr::List { .. }
-        | TypedExpr::Call { .. }
-        | TypedExpr::BinOp { .. }
-        | TypedExpr::Case { .. }
-        | TypedExpr::RecordAccess { .. }
-        | TypedExpr::PositionalAccess { .. }
-        | TypedExpr::ModuleSelect { .. }
-        | TypedExpr::Tuple { .. }
-        | TypedExpr::TupleIndex { .. }
-        | TypedExpr::Todo { .. }
-        | TypedExpr::Panic { .. }
-        | TypedExpr::Echo { .. }
-        | TypedExpr::BitArray { .. }
-        | TypedExpr::RecordUpdate { .. }
-        | TypedExpr::NegateBool { .. }
-        | TypedExpr::NegateInt { .. }
-        | TypedExpr::Invalid { .. } => false,
-    }
-}
-
-/// This returns true if the given constant is going to be compiled to a
-/// single literal Erlang string.
-/// This is not only true for literal Gleam strings like `"abc"`, but also for
-/// variables referencing string constants (as those are inlined)
-fn constant_produces_literal_string(constant: &Constant<Arc<Type>>) -> bool {
-    match constant {
-        Constant::String { .. } => true,
-        Constant::Var {
-            constructor: Some(constructor),
-            ..
-        } if let ValueConstructor {
-            variant: ValueConstructorVariant::ModuleConstant { ref literal, .. },
-            ..
-        } = **constructor =>
-        {
-            constant_produces_literal_string(literal)
-        }
-        Constant::Int { .. }
-        | Constant::Float { .. }
-        | Constant::Tuple { .. }
-        | Constant::List { .. }
-        | Constant::Record { .. }
-        | Constant::RecordUpdate { .. }
-        | Constant::BitArray { .. }
-        | Constant::BinaryOperator { .. }
-        | Constant::Invalid { .. }
-        | Constant::Todo { .. }
-        | Constant::Var { .. } => false,
-    }
-}
-
-/// This returns true if the given guard is going to be compiled to a
-/// single literal Erlang string.
-/// This is not only true for literal Gleam strings like `"abc"`, but also for
-/// variables referencing string constants (as those are inlined)
-fn guard_produces_literal_string(guard: &ClauseGuard<Arc<Type>>) -> bool {
-    match guard {
-        ClauseGuard::Block { value, .. } => guard_produces_literal_string(value),
-
-        ClauseGuard::Constant(constant) => constant_produces_literal_string(constant),
-
-        ClauseGuard::BinaryOperator { .. }
-        | ClauseGuard::ModuleSelect { .. }
-        | ClauseGuard::Not { .. }
-        | ClauseGuard::LocalVariable { .. }
-        | ClauseGuard::TupleIndex { .. }
-        | ClauseGuard::FieldAccess { .. }
-        | ClauseGuard::UnqualifiedRemoteConstant { .. }
-        | ClauseGuard::Invalid { .. } => false,
-    }
 }
 
 static ATOM_PATTERN: OnceLock<Regex> = OnceLock::new();

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -1160,9 +1160,12 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
             // Module constants.
             //
             TypedExpr::ModuleSelect {
-                constructor: ModuleValueConstructor::Constant { literal, .. },
+                constructor: ModuleValueConstructor::Constant { .. },
+                module_name,
+                label,
+                location,
                 ..
-            } => self.constant(builder, literal),
+            } => self.remote_constant(builder, *location, module_name, label),
 
             //
             // Control flow.
@@ -3795,13 +3798,10 @@ fn type_export(custom_type: &TypedCustomType) -> (EcoString, usize) {
 fn produces_literal_string(value: &TypedExpr) -> bool {
     match value {
         TypedExpr::String { .. } => true,
+
         // Constants are inlined on the Erlang target, so we need to check if
         // those produce literal strings too!
-        TypedExpr::ModuleSelect {
-            constructor: ModuleValueConstructor::Constant { literal, .. },
-            ..
-        }
-        | TypedExpr::Var {
+        TypedExpr::Var {
             constructor:
                 ValueConstructor {
                     variant: ValueConstructorVariant::ModuleConstant { literal, .. },

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__constant_named_module_info_imported.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__constant_named_module_info_imported.snap
@@ -18,4 +18,4 @@ pub fn main() {
 
 -spec main() -> integer().
 main() ->
-    1.
+    some_module:'moduleInfo'().

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__constant_named_module_info_with_function_inside_imported.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__constant_named_module_info_with_function_inside_imported.snap
@@ -18,4 +18,4 @@ pub fn main() {
 
 -spec main() -> integer().
 main() ->
-    fun some_module:function/0().
+    (some_module:'moduleInfo'())().

--- a/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__function_named_module_info_in_constant_imported.snap
+++ b/compiler-core/src/erlang/snapshots/gleam_core__erlang__tests__function_named_module_info_in_constant_imported.snap
@@ -18,4 +18,4 @@ pub fn main() {
 
 -spec main() -> integer().
 main() ->
-    fun some_module:'moduleInfo'/0().
+    (some_module:constant())().

--- a/compiler-core/src/erlang/tests/consts.rs
+++ b/compiler-core/src/erlang/tests/consts.rs
@@ -558,3 +558,124 @@ pub fn go(x) {
 "#
     );
 }
+
+#[test]
+fn constant_string_concatenation_with_qualified_remote_constant() {
+    assert_erl!(
+        (
+            "dep",
+            "mod",
+            r#"
+pub const name = "Giacomo"
+"#
+        ),
+        r#"
+import mod
+pub const greeting = "Hello, " <> mod.name <> "!"
+"#
+    );
+}
+
+#[test]
+fn constant_string_concatenation_with_unqualified_remote_constant() {
+    assert_erl!(
+        (
+            "dep",
+            "mod",
+            r#"
+pub const name = "Giacomo"
+"#
+        ),
+        r#"
+import mod.{name}
+pub const greeting = "Hello, " <> name <> "!"
+"#
+    );
+}
+
+#[test]
+fn guard_string_concatenation_with_qualified_remote_constant() {
+    assert_erl!(
+        (
+            "dep",
+            "mod",
+            r#"
+pub const name = "Giacomo"
+"#
+        ),
+        r#"
+import mod
+
+pub fn go(x) {
+  case x {
+    _ if "Hello, " <> mod.name <> "!" == "" -> Nil
+    _ -> Nil
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn guard_string_concatenation_with_unqualified_remote_constant() {
+    assert_erl!(
+        (
+            "dep",
+            "mod",
+            r#"
+pub const name = "Giacomo"
+"#
+        ),
+        r#"
+import mod.{name}
+
+pub fn go(x) {
+  case x {
+    _ if "Hello, " <> name <> "!" == "" -> Nil
+    _ -> Nil
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn string_concatenation_with_qualified_remote_constant() {
+    assert_erl!(
+        (
+            "dep",
+            "mod",
+            r#"
+pub const name = "Giacomo"
+"#
+        ),
+        r#"
+import mod
+
+pub fn wibble() {
+  "Hello, " <> mod.name <> "!"
+}
+"#
+    );
+}
+
+#[test]
+fn string_concatenation_with_unqualified_remote_constant() {
+    assert_erl!(
+        (
+            "dep",
+            "mod",
+            r#"
+pub const name = "Giacomo"
+"#
+        ),
+        r#"
+import mod.{name}
+
+pub fn wibble() {
+  "Hello, " <> name <> "!"
+}
+
+"#
+    );
+}

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_imported_aliased_string_in_bit_array_segment_test_with_utf16_option.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_imported_aliased_string_in_bit_array_segment_test_with_utf16_option.snap
@@ -21,5 +21,5 @@ pub fn main() {
 
 -spec main() -> nil.
 main() ->
-    _ = <<(some_module:wibble())/utf16>>,
+    _ = <<(unicode:characters_to_binary(some_module:wibble(), utf8, {utf16, big}))/binary>>,
     nil.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_imported_aliased_string_in_bit_array_segment_test_with_utf16_option_2.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_imported_aliased_string_in_bit_array_segment_test_with_utf16_option_2.snap
@@ -22,5 +22,5 @@ pub fn main() {
 
 -spec main() -> nil.
 main() ->
-    _ = <<(some_module:wibble())/utf16>>,
+    _ = <<(unicode:characters_to_binary(some_module:wibble(), utf8, {utf16, big}))/binary>>,
     nil.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_imported_aliased_string_in_bit_array_segment_test_with_utf8_option.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_imported_aliased_string_in_bit_array_segment_test_with_utf8_option.snap
@@ -21,5 +21,5 @@ pub fn main() {
 
 -spec main() -> nil.
 main() ->
-    _ = <<(some_module:wibble())/utf8>>,
+    _ = <<(some_module:wibble())/binary>>,
     nil.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_imported_aliased_string_in_bit_array_segment_test_with_utf8_option_2.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_imported_aliased_string_in_bit_array_segment_test_with_utf8_option_2.snap
@@ -22,5 +22,5 @@ pub fn main() {
 
 -spec main() -> nil.
 main() ->
-    _ = <<(some_module:wibble())/utf8>>,
+    _ = <<(some_module:wibble())/binary>>,
     nil.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_imported_aliased_string_in_string_concatenation.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_imported_aliased_string_in_string_concatenation.snap
@@ -21,4 +21,4 @@ pub fn main() {
 
 -spec main() -> binary().
 main() ->
-    _ = <<(some_module:wibble())/utf8, "b"/utf8>>.
+    _ = <<(some_module:wibble())/binary, "b"/utf8>>.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_imported_aliased_string_in_string_concatenation_in_guard.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_imported_aliased_string_in_string_concatenation_in_guard.snap
@@ -26,7 +26,7 @@ pub fn go(x) {
 go(X) ->
     _value = some_module:wibble(),
     case X of
-        X@1 when X@1 =:= <<_value/utf8, "b"/utf8>> ->
+        X@1 when X@1 =:= <<_value/binary, "b"/utf8>> ->
             erlang:error(#{
                 gleam_error => todo,
                 message => ~"`todo` expression evaluated. This code has not yet been implemented.",

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_string_concatenation_with_qualified_remote_constant.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_string_concatenation_with_qualified_remote_constant.snap
@@ -1,0 +1,18 @@
+---
+source: compiler-core/src/erlang/tests/consts.rs
+expression: "\nimport mod\npub const greeting = \"Hello, \" <> mod.name <> \"!\"\n"
+---
+----- SOURCE CODE
+
+import mod
+pub const greeting = "Hello, " <> mod.name <> "!"
+
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_ignored, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
+-export([greeting/0]).
+
+-spec greeting() -> binary().
+greeting() ->
+    <<"Hello, "/utf8, (mod:name())/binary, "!"/utf8>>.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_string_concatenation_with_unqualified_remote_constant.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__constant_string_concatenation_with_unqualified_remote_constant.snap
@@ -1,0 +1,18 @@
+---
+source: compiler-core/src/erlang/tests/consts.rs
+expression: "\nimport mod.{name}\npub const greeting = \"Hello, \" <> name <> \"!\"\n"
+---
+----- SOURCE CODE
+
+import mod.{name}
+pub const greeting = "Hello, " <> name <> "!"
+
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_ignored, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
+-export([greeting/0]).
+
+-spec greeting() -> binary().
+greeting() ->
+    <<"Hello, "/utf8, (mod:name())/binary, "!"/utf8>>.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__guard_string_concatenation_with_qualified_remote_constant.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__guard_string_concatenation_with_qualified_remote_constant.snap
@@ -1,0 +1,31 @@
+---
+source: compiler-core/src/erlang/tests/consts.rs
+expression: "\nimport mod\n\npub fn go(x) {\n  case x {\n    _ if \"Hello, \" <> mod.name <> \"!\" == \"\" -> Nil\n    _ -> Nil\n  }\n}\n"
+---
+----- SOURCE CODE
+
+import mod
+
+pub fn go(x) {
+  case x {
+    _ if "Hello, " <> mod.name <> "!" == "" -> Nil
+    _ -> Nil
+  }
+}
+
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_ignored, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
+-export([go/1]).
+
+-spec go(any()) -> nil.
+go(X) ->
+    _value = mod:name(),
+    case X of
+        _ when <<<<"Hello, "/utf8, _value/binary>>/binary, "!"/utf8>> =:= ~"" ->
+            nil;
+
+        _ ->
+            nil
+    end.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__guard_string_concatenation_with_unqualified_remote_constant.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__guard_string_concatenation_with_unqualified_remote_constant.snap
@@ -1,0 +1,31 @@
+---
+source: compiler-core/src/erlang/tests/consts.rs
+expression: "\nimport mod.{name}\n\npub fn go(x) {\n  case x {\n    _ if \"Hello, \" <> name <> \"!\" == \"\" -> Nil\n    _ -> Nil\n  }\n}\n"
+---
+----- SOURCE CODE
+
+import mod.{name}
+
+pub fn go(x) {
+  case x {
+    _ if "Hello, " <> name <> "!" == "" -> Nil
+    _ -> Nil
+  }
+}
+
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_ignored, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
+-export([go/1]).
+
+-spec go(any()) -> nil.
+go(X) ->
+    _value = mod:name(),
+    case X of
+        _ when <<<<"Hello, "/utf8, _value/binary>>/binary, "!"/utf8>> =:= ~"" ->
+            nil;
+
+        _ ->
+            nil
+    end.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__string_concatenation_with_qualified_remote_constant.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__string_concatenation_with_qualified_remote_constant.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/erlang/tests/consts.rs
+expression: "\nimport mod\n\npub fn wibble() {\n  \"Hello, \" <> mod.name <> \"!\"\n}\n"
+---
+----- SOURCE CODE
+
+import mod
+
+pub fn wibble() {
+  "Hello, " <> mod.name <> "!"
+}
+
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_ignored, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
+-export([wibble/0]).
+
+-spec wibble() -> binary().
+wibble() ->
+    <<<<"Hello, "/utf8, (mod:name())/binary>>/binary, "!"/utf8>>.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__string_concatenation_with_unqualified_remote_constant.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__string_concatenation_with_unqualified_remote_constant.snap
@@ -1,0 +1,22 @@
+---
+source: compiler-core/src/erlang/tests/consts.rs
+expression: "\nimport mod.{name}\n\npub fn wibble() {\n  \"Hello, \" <> name <> \"!\"\n}\n\n"
+---
+----- SOURCE CODE
+
+import mod.{name}
+
+pub fn wibble() {
+  "Hello, " <> name <> "!"
+}
+
+
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_ignored, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
+-export([wibble/0]).
+
+-spec wibble() -> binary().
+wibble() ->
+    <<<<"Hello, "/utf8, (mod:name())/binary>>/binary, "!"/utf8>>.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__string_constant_from_another_module_is_concatenated_correctly.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__string_constant_from_another_module_is_concatenated_correctly.snap
@@ -18,4 +18,4 @@ pub fn go(x) {
 
 -spec go(binary()) -> binary().
 go(X) ->
-    <<<<X/binary, "-"/utf8>>/binary, "wibble!"/utf8>>.
+    <<<<X/binary, "-"/utf8>>/binary, (mod:wibble())/binary>>.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__string_constant_from_another_module_is_concatenated_correctly_2.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__consts__string_constant_from_another_module_is_concatenated_correctly_2.snap
@@ -18,4 +18,4 @@ pub fn go(x) {
 
 -spec go(binary()) -> binary().
 go(X) ->
-    <<<<X/binary, "-"/utf8>>/binary, (mod:wibble())/utf8>>.
+    <<<<X/binary, "-"/utf8>>/binary, (mod:wibble())/binary>>.

--- a/test/language/test/language/constant.gleam
+++ b/test/language/test/language/constant.gleam
@@ -1,0 +1,18 @@
+//// This module defines constants that can be imported to check imported
+//// constants are handled correctly by the compiler.
+////
+
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2026 The Gleam contributors
+
+pub const a_string = "hello"
+
+pub const a_number = 11
+
+pub const a_value = Wibble(11)
+
+pub const a_constructor = Wibble
+
+pub type Wibble {
+  Wibble(Int)
+}

--- a/test/language/test/language/constant_test.gleam
+++ b/test/language/test/language/constant_test.gleam
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2026 The Gleam contributors
 
-import language/constant
+import language/constant.{a_string}
 
 const const_int = 5
 
@@ -88,4 +88,30 @@ pub fn qualified_constant_int_test() {
 pub fn qualified_constant_constructor_test() {
   assert constant.a_constructor(11) == constant.a_value
   assert constant.a_constructor(11) == constant.Wibble(11)
+}
+
+const qualified_message = "message:" <> constant.a_string <> "."
+
+pub fn qualified_string_concat_in_constants_works_the_same_as_in_expressions_test() {
+  assert qualified_message == "message:" <> constant.a_string <> "."
+}
+
+const unqualified_message = "message:" <> a_string <> "."
+
+pub fn unqualified_string_concat_in_constants_works_the_same_as_in_expressions_test() {
+  assert unqualified_message == "message:" <> a_string <> "."
+}
+
+pub fn qualified_string_concat_in_guard_test() {
+  case Nil {
+    _ if "message:" <> constant.a_string <> "." == qualified_message -> Nil
+    _ -> panic
+  }
+}
+
+pub fn unqualified_string_concat_in_guard_test() {
+  case Nil {
+    _ if "message:" <> a_string <> "." == unqualified_message -> Nil
+    _ -> panic
+  }
 }

--- a/test/language/test/language/constant_test.gleam
+++ b/test/language/test/language/constant_test.gleam
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2026 The Gleam contributors
 
+import language/constant
+
 const const_int = 5
 
 const const_float = 1.0
@@ -72,4 +74,18 @@ pub fn constant_aliased_string_in_bit_arrays_test() {
     wibble if wibble == message_2 <> "!" -> True
     _ -> False
   }
+}
+
+pub fn qualified_constant_string_test() {
+  assert constant.a_string == "hello"
+  assert constant.a_string <> ", world" == "hello, world"
+}
+
+pub fn qualified_constant_int_test() {
+  assert constant.a_number == 11
+}
+
+pub fn qualified_constant_constructor_test() {
+  assert constant.a_constructor(11) == constant.a_value
+  assert constant.a_constructor(11) == constant.Wibble(11)
 }


### PR DESCRIPTION
This PR fixes #6231 
This PR fixes #6232 

This PR fixes a codegen bug on main with constants when they are used in a qualified manner from a different module I forgot to not inline them