### PR TITLE
replace toList with prepend calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,9 @@
   OTP29.
   ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
 
+- Creation of literal lists has been optimised on the JavaScript target.
+  ([Giacomo Cavalieri](https://github.com/giacomocavalieri))
+
 - The compiler now provides a specific error message directing the user to the
   correct syntax when trying to update a record after providing fields.
   ([0xda157](https://github.com/0xda157))

--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -224,7 +224,7 @@ impl<'a, 'doc> Generator<'a> {
             self.register_prelude_usage(arena, &mut imports, "Error", None);
         }
 
-        if self.tracker.list_used {
+        if self.tracker.to_list_used {
             self.register_prelude_usage(arena, &mut imports, "toList", None);
         }
 
@@ -1566,7 +1566,7 @@ fn maybe_escape_property(label: &str) -> EcoString {
 #[derive(Debug, Default)]
 pub(crate) struct UsageTracker {
     pub ok_used: bool,
-    pub list_used: bool,
+    pub to_list_used: bool,
     pub list_empty_class_used: bool,
     pub list_empty_const_used: bool,
     pub list_non_empty_class_used: bool,

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -421,27 +421,13 @@ impl<'module, 'a, 'doc> Generator<'module, 'a, 'doc> {
 
             TypedExpr::List { elements, tail, .. } => {
                 self.not_in_tail_position(Some(Ordering::Strict), |this| match tail {
-                    Some(tail) => {
-                        this.tracker.prepend_used = true;
-                        let tail = this.wrap_expression(arena, tail);
-                        prepend(
-                            arena,
-                            elements
-                                .iter()
-                                .map(|element| this.wrap_expression(arena, element)),
-                            tail,
-                        )
-                    }
+                    Some(tail) => this.prepend(arena, elements.iter(), tail, |this, element| {
+                        this.wrap_expression(arena, element)
+                    }),
                     None if elements.is_empty() => this.empty_list(),
-                    None => {
-                        this.tracker.list_used = true;
-                        list(
-                            arena,
-                            elements
-                                .iter()
-                                .map(|element| this.wrap_expression(arena, element)),
-                        )
-                    }
+                    None => this.list(arena, elements.len(), elements.iter(), |this, element| {
+                        this.wrap_expression(arena, element)
+                    }),
                 })
             }
 
@@ -2707,43 +2693,31 @@ impl<'module, 'a, 'doc> Generator<'module, 'a, 'doc> {
                     return self.empty_list();
                 }
 
-                self.tracker.list_used = true;
                 let list = match tail {
                     // There's no tail in the list, we join all the elements and
                     // call it a day.
-                    None => list(
-                        arena,
-                        elements
-                            .iter()
-                            .map(|element| self.constant_expression(arena, context, element)),
-                    ),
+                    None => self.list(arena, elements.len(), elements.iter(), |this, element| {
+                        this.constant_expression(arena, context, element)
+                    }),
 
                     Some(tail) => match tail.list_elements() {
                         // There's a tail in the list whose elements are all
                         // known at compile time. In this case we replace the
                         // tail with those elements and create a single flat
                         // list.
-                        Some(tail_elements) => list(
+                        Some(tail_elements) => self.list(
                             arena,
-                            elements
-                                .iter()
-                                .chain(tail_elements)
-                                .map(|element| self.constant_expression(arena, context, element)),
+                            elements.len() + tail_elements.len(),
+                            elements.iter().chain(tail_elements),
+                            |this, element| this.constant_expression(arena, context, element),
                         ),
+
                         // There's a tail in the list but we can't really tell
                         // what its elements are at compile time. This means we
                         // have to prepend to this list.
-                        None => {
-                            self.tracker.prepend_used = true;
-                            let tail = self.constant_expression(arena, context, tail);
-                            prepend(
-                                arena,
-                                elements.iter().map(|element| {
-                                    self.constant_expression(arena, context, element)
-                                }),
-                                tail,
-                            )
-                        }
+                        None => self.prepend(arena, elements.iter(), tail, |this, element| {
+                            this.constant_expression(arena, context, element)
+                        }),
                     },
                 };
                 match context {
@@ -3532,7 +3506,64 @@ impl<'module, 'a, 'doc> Generator<'module, 'a, 'doc> {
             ]
         }
     }
+
+    fn list<Element>(
+        &mut self,
+        arena: &'doc DocumentArena<'a, 'doc>,
+        count: usize,
+        elements: impl DoubleEndedIterator<Item = Element>,
+        to_doc: impl Fn(&mut Self, Element) -> Document<'a, 'doc>,
+    ) -> Document<'a, 'doc> {
+        if count > MAX_PREPEND_LIST_SIZE {
+            self.tracker.to_list_used = true;
+            docvec![
+                arena,
+                TO_LIST_OPEN_PAREN_DOCUMENT,
+                array(
+                    arena,
+                    elements.into_iter().map(|element| to_doc(self, element)),
+                ),
+                CLOSE_PAREN_DOCUMENT
+            ]
+        } else {
+            self.tracker.prepend_used = true;
+            self.tracker.list_empty_const_used = true;
+            elements
+                .into_iter()
+                .map(|element| to_doc(self, element))
+                .rev()
+                .fold(
+                    DOLLAR_LIST_DOLLAR_EMPTY_DOLLAR_CONST_DOCUMENT,
+                    |tail, element| {
+                        let arguments = call_arguments(arena, [element, tail]);
+                        docvec![arena, LIST_PREPEND_DOCUMENT, arguments]
+                    },
+                )
+        }
+    }
+
+    fn prepend<Element>(
+        &mut self,
+        arena: &'doc DocumentArena<'a, 'doc>,
+        elements: impl DoubleEndedIterator<Item = Element>,
+        tail: Element,
+        to_doc: impl Fn(&mut Self, Element) -> Document<'a, 'doc>,
+    ) -> Document<'a, 'doc> {
+        self.tracker.prepend_used = true;
+
+        let tail = to_doc(self, tail);
+        elements
+            .into_iter()
+            .map(|element| to_doc(self, element))
+            .rev()
+            .fold(tail, |tail, element| {
+                let arguments = call_arguments(arena, [element, tail]);
+                docvec![arena, LIST_PREPEND_DOCUMENT, arguments]
+            })
+    }
 }
+
+const MAX_PREPEND_LIST_SIZE: usize = 10;
 
 #[derive(Clone, Copy)]
 enum AssertExpression {
@@ -3728,36 +3759,6 @@ pub(crate) fn array<'a, 'doc, Elements: IntoIterator<Item = Document<'a, 'doc>>>
         ]
         .group(arena)
     }
-}
-
-pub(crate) fn list<'a, 'doc, I: IntoIterator<Item = Document<'a, 'doc>>>(
-    arena: &'doc DocumentArena<'a, 'doc>,
-    elements: I,
-) -> Document<'a, 'doc>
-where
-    I::IntoIter: DoubleEndedIterator,
-{
-    let array = array(arena, elements);
-    docvec![
-        arena,
-        TO_LIST_OPEN_PAREN_DOCUMENT,
-        array,
-        CLOSE_PAREN_DOCUMENT
-    ]
-}
-
-fn prepend<'a, 'doc, I: IntoIterator<Item = Document<'a, 'doc>>>(
-    arena: &'doc DocumentArena<'a, 'doc>,
-    elements: I,
-    tail: Document<'a, 'doc>,
-) -> Document<'a, 'doc>
-where
-    I::IntoIter: DoubleEndedIterator + ExactSizeIterator,
-{
-    elements.into_iter().rev().fold(tail, |tail, element| {
-        let arguments = call_arguments(arena, [element, tail]);
-        docvec![arena, LIST_PREPEND_DOCUMENT, arguments]
-    })
 }
 
 fn call_arguments<'a, 'doc, Elements: IntoIterator<Item = Document<'a, 'doc>>>(

--- a/compiler-core/src/javascript/tests/lists.rs
+++ b/compiler-core/src/javascript/tests/lists.rs
@@ -164,3 +164,14 @@ pub fn go(x) {
 "
     );
 }
+
+#[test]
+fn long_list_is_generated_using_to_list_function() {
+    assert_js!(
+        "
+pub fn list() {
+  [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+}
+"
+    );
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__list_with_tail_used_in_guard.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__list_with_tail_used_in_guard.snap
@@ -12,7 +12,7 @@ pub fn go(x: List(Int), y: List(Int)) {
 }
 
 ----- COMPILED JAVASCRIPT
-import { toList, Empty as $Empty, prepend as listPrepend, isEqual } from "../gleam.mjs";
+import { Empty as $Empty, prepend as listPrepend, isEqual } from "../gleam.mjs";
 
 export function go(x, y) {
   if (x instanceof $Empty) {

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__nested_string_prefix_match.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__nested_string_prefix_match.snap
@@ -13,10 +13,17 @@ pub fn main() {
 
 
 ----- COMPILED JAVASCRIPT
-import { Ok, toList, Empty as $Empty } from "../gleam.mjs";
+import {
+  Ok,
+  Empty as $Empty,
+  List$Empty$const as $List$Empty$const,
+  prepend as listPrepend,
+} from "../gleam.mjs";
 
 export function main() {
-  let $ = new Ok(toList(["a", "b c", "d"]));
+  let $ = new Ok(
+    listPrepend("a", listPrepend("b c", listPrepend("d", $List$Empty$const))),
+  );
   let $1 = $[0];
   if ($1 instanceof $Empty) {
     return 1;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__nested_string_prefix_match_that_would_crash_on_js.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case__nested_string_prefix_match_that_would_crash_on_js.snap
@@ -13,10 +13,15 @@ pub fn main() {
 
 
 ----- COMPILED JAVASCRIPT
-import { Ok, toList, Empty as $Empty } from "../gleam.mjs";
+import {
+  Ok,
+  Empty as $Empty,
+  List$Empty$const as $List$Empty$const,
+  prepend as listPrepend,
+} from "../gleam.mjs";
 
 export function main() {
-  let $ = new Ok(toList(["b c", "d"]));
+  let $ = new Ok(listPrepend("b c", listPrepend("d", $List$Empty$const)));
   let $1 = $[0];
   if ($1 instanceof $Empty) {
     return 1;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__constructor_function_in_guard.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__constructor_function_in_guard.snap
@@ -12,11 +12,18 @@ pub fn func(x) {
     
 
 ----- COMPILED JAVASCRIPT
-import { Ok, toList, Empty as $Empty, List$Empty$const as $List$Empty$const } from "../gleam.mjs";
+import {
+  Ok,
+  Empty as $Empty,
+  List$Empty$const as $List$Empty$const,
+  prepend as listPrepend,
+} from "../gleam.mjs";
 
 export function func(x) {
   let $ = $List$Empty$const;
-  if (toList([(var0) => { return new Ok(var0); }]) instanceof $Empty) {
+  if (
+    listPrepend((var0) => { return new Ok(var0); }, $List$Empty$const) instanceof $Empty
+  ) {
     return true;
   } else {
     return false;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__imported_ok.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__imported_ok.snap
@@ -17,7 +17,12 @@ pub fn func(x) {
 
 ----- COMPILED JAVASCRIPT
 import * as $gleam from "../gleam.mjs";
-import { toList, Empty as $Empty, CustomType as $CustomType } from "../gleam.mjs";
+import {
+  Empty as $Empty,
+  List$Empty$const as $List$Empty$const,
+  prepend as listPrepend,
+  CustomType as $CustomType,
+} from "../gleam.mjs";
 
 export class Ok extends $CustomType {}
 export const X$Ok$const = new Ok();
@@ -26,7 +31,9 @@ export const X$isOk = (value) => value instanceof Ok;
 
 export function func(x) {
   let $ = (var0) => { return new $gleam.Ok(var0); };
-  if (toList([(var0) => { return new $gleam.Ok(var0); }]) instanceof $Empty) {
+  if (
+    listPrepend((var0) => { return new $gleam.Ok(var0); }, $List$Empty$const) instanceof $Empty
+  ) {
     return true;
   } else {
     return false;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__keyword_var.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__keyword_var.snap
@@ -22,7 +22,7 @@ pub fn main() {
 
 
 ----- COMPILED JAVASCRIPT
-import { toList, isEqual } from "../gleam.mjs";
+import { List$Empty$const as $List$Empty$const, prepend as listPrepend, isEqual } from "../gleam.mjs";
 
 export const function$ = 5;
 
@@ -34,7 +34,12 @@ export function main() {
   let var$ = 7;
   if (class$ === while$) {
     return true;
-  } else if (isEqual(toList([class$]), toList([5]))) {
+  } else if (
+    isEqual(
+      listPrepend(class$, $List$Empty$const),
+      listPrepend(5, $List$Empty$const)
+    )
+  ) {
     return true;
   } else {
     let function$1 = var$;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__module_list_access.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__case_clause_guards__module_list_access.snap
@@ -16,10 +16,13 @@ expression: "\n          import hero\n          pub fn main() {\n            let
 
 ----- COMPILED JAVASCRIPT
 import * as $hero from "../../package/hero.mjs";
-import { toList, isEqual } from "../gleam.mjs";
+import { List$Empty$const as $List$Empty$const, prepend as listPrepend, isEqual } from "../gleam.mjs";
 
 export function main() {
-  let names = toList(["Tony Stark", "Bruce Wayne"]);
+  let names = listPrepend(
+    "Tony Stark",
+    listPrepend("Bruce Wayne", $List$Empty$const),
+  );
   let n = names;
   if (isEqual(n, $hero.heroes)) {
     return true;

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__consts__constant_constructor_gets_pure_annotation.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__consts__constant_constructor_gets_pure_annotation.snap
@@ -14,8 +14,8 @@ pub const y = X(1, [])
 
 ----- COMPILED JAVASCRIPT
 import {
-  toList,
   List$Empty$const as $List$Empty$const,
+  prepend as listPrepend,
   CustomType as $CustomType,
 } from "../gleam.mjs";
 
@@ -31,6 +31,9 @@ export const X$isX = (value) => value instanceof X;
 export const X$X$0 = (value) => value[0];
 export const X$X$1 = (value) => value[1];
 
-export const x = /* @__PURE__ */ new X(1, /* @__PURE__ */ toList(["1"]));
+export const x = /* @__PURE__ */ new X(
+  1,
+  /* @__PURE__ */ listPrepend("1", $List$Empty$const),
+);
 
 export const y = /* @__PURE__ */ new X(1, $List$Empty$const);

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__consts__constant_list_with_constructors_gets_pure_annotation.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__consts__constant_list_with_constructors_gets_pure_annotation.snap
@@ -13,7 +13,11 @@ pub const y = [X(1, ["1"])]
         
 
 ----- COMPILED JAVASCRIPT
-import { toList, CustomType as $CustomType } from "../gleam.mjs";
+import {
+  List$Empty$const as $List$Empty$const,
+  prepend as listPrepend,
+  CustomType as $CustomType,
+} from "../gleam.mjs";
 
 export class X extends $CustomType {
   constructor($0, $1) {
@@ -27,10 +31,12 @@ export const X$isX = (value) => value instanceof X;
 export const X$X$0 = (value) => value[0];
 export const X$X$1 = (value) => value[1];
 
-export const x = /* @__PURE__ */ toList([
-  /* @__PURE__ */ new X(1, /* @__PURE__ */ toList(["1"])),
-]);
+export const x = /* @__PURE__ */ listPrepend(
+  /* @__PURE__ */ new X(1, /* @__PURE__ */ listPrepend("1", $List$Empty$const)),
+  $List$Empty$const,
+);
 
-export const y = /* @__PURE__ */ toList([
-  /* @__PURE__ */ new X(1, /* @__PURE__ */ toList(["1"])),
-]);
+export const y = /* @__PURE__ */ listPrepend(
+  /* @__PURE__ */ new X(1, /* @__PURE__ */ listPrepend("1", $List$Empty$const)),
+  $List$Empty$const,
+);

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__consts__constant_tuple_with_constructors_gets_pure_annotation.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__consts__constant_tuple_with_constructors_gets_pure_annotation.snap
@@ -13,7 +13,11 @@ pub const y = #(X(1, ["1"]))
         
 
 ----- COMPILED JAVASCRIPT
-import { toList, CustomType as $CustomType } from "../gleam.mjs";
+import {
+  List$Empty$const as $List$Empty$const,
+  prepend as listPrepend,
+  CustomType as $CustomType,
+} from "../gleam.mjs";
 
 export class X extends $CustomType {
   constructor($0, $1) {
@@ -27,6 +31,10 @@ export const X$isX = (value) => value instanceof X;
 export const X$X$0 = (value) => value[0];
 export const X$X$1 = (value) => value[1];
 
-export const x = [/* @__PURE__ */ new X(1, /* @__PURE__ */ toList(["1"]))];
+export const x = [
+  /* @__PURE__ */ new X(1, /* @__PURE__ */ listPrepend("1", $List$Empty$const)),
+];
 
-export const y = [/* @__PURE__ */ new X(1, /* @__PURE__ */ toList(["1"]))];
+export const y = [
+  /* @__PURE__ */ new X(1, /* @__PURE__ */ listPrepend("1", $List$Empty$const)),
+];

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__consts__list_prepend.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__consts__list_prepend.snap
@@ -9,8 +9,17 @@ pub const wobble = [0, 1, ..wibble]
 
 
 ----- COMPILED JAVASCRIPT
-import { toList } from "../gleam.mjs";
+import { List$Empty$const as $List$Empty$const, prepend as listPrepend } from "../gleam.mjs";
 
-const wibble = /* @__PURE__ */ toList([2, 3, 4]);
+const wibble = /* @__PURE__ */ listPrepend(
+  2,
+  listPrepend(3, listPrepend(4, $List$Empty$const)),
+);
 
-export const wobble = /* @__PURE__ */ toList([0, 1, 2, 3, 4]);
+export const wobble = /* @__PURE__ */ listPrepend(
+  0,
+  listPrepend(
+    1,
+    listPrepend(2, listPrepend(3, listPrepend(4, $List$Empty$const))),
+  ),
+);

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__consts__list_prepend_from_other_module.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__consts__list_prepend_from_other_module.snap
@@ -14,7 +14,13 @@ pub const wobble = [0, 1, ..mod.wibble]
 
 
 ----- COMPILED JAVASCRIPT
-import { toList } from "../gleam.mjs";
+import { List$Empty$const as $List$Empty$const, prepend as listPrepend } from "../gleam.mjs";
 import * as $mod from "../mod.mjs";
 
-export const wobble = /* @__PURE__ */ toList([0, 1, 2, 3, 4]);
+export const wobble = /* @__PURE__ */ listPrepend(
+  0,
+  listPrepend(
+    1,
+    listPrepend(2, listPrepend(3, listPrepend(4, $List$Empty$const))),
+  ),
+);

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__consts__list_prepend_literal.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__consts__list_prepend_literal.snap
@@ -8,6 +8,12 @@ pub const wibble = [0, 1, ..[2, 3, 4]]
 
 
 ----- COMPILED JAVASCRIPT
-import { toList } from "../gleam.mjs";
+import { List$Empty$const as $List$Empty$const, prepend as listPrepend } from "../gleam.mjs";
 
-export const wibble = /* @__PURE__ */ toList([0, 1, 2, 3, 4]);
+export const wibble = /* @__PURE__ */ listPrepend(
+  0,
+  listPrepend(
+    1,
+    listPrepend(2, listPrepend(3, listPrepend(4, $List$Empty$const))),
+  ),
+);

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__consts__literal_list_does_not_get_constant_annotation.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__consts__literal_list_does_not_get_constant_annotation.snap
@@ -6,6 +6,9 @@ expression: "pub const a = [1, 2, 3]"
 pub const a = [1, 2, 3]
 
 ----- COMPILED JAVASCRIPT
-import { toList } from "../gleam.mjs";
+import { List$Empty$const as $List$Empty$const, prepend as listPrepend } from "../gleam.mjs";
 
-export const a = /* @__PURE__ */ toList([1, 2, 3]);
+export const a = /* @__PURE__ */ listPrepend(
+  1,
+  listPrepend(2, listPrepend(3, $List$Empty$const)),
+);

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__echo__echo_in_a_pipeline.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__echo__echo_in_a_pipeline.snap
@@ -16,9 +16,10 @@ pub fn wibble(n) { n }
 ----- COMPILED JAVASCRIPT
 import * as $stdlib$dict from "../../gleam_stdlib/gleam/dict.mjs";
 import {
-  toList,
   Empty as $Empty,
+  List$Empty$const as $List$Empty$const,
   NonEmpty as $NonEmpty,
+  prepend as listPrepend,
   CustomType as $CustomType,
   bitArraySlice,
   bitArraySliceToInt,
@@ -32,7 +33,7 @@ export function wibble(n) {
 }
 
 export function main() {
-  let _pipe = toList([1, 2, 3]);
+  let _pipe = listPrepend(1, listPrepend(2, listPrepend(3, $List$Empty$const)));
   echo(_pipe, undefined, "src/module.gleam", 4);
   return wibble(_pipe);
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__echo__echo_in_a_pipeline_with_message.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__echo__echo_in_a_pipeline_with_message.snap
@@ -16,9 +16,10 @@ pub fn wibble(n) { n }
 ----- COMPILED JAVASCRIPT
 import * as $stdlib$dict from "../../gleam_stdlib/gleam/dict.mjs";
 import {
-  toList,
   Empty as $Empty,
+  List$Empty$const as $List$Empty$const,
   NonEmpty as $NonEmpty,
+  prepend as listPrepend,
   CustomType as $CustomType,
   bitArraySlice,
   bitArraySliceToInt,
@@ -32,7 +33,7 @@ export function wibble(n) {
 }
 
 export function main() {
-  let _pipe = toList([1, 2, 3]);
+  let _pipe = listPrepend(1, listPrepend(2, listPrepend(3, $List$Empty$const)));
   echo(_pipe, "message!!", "src/module.gleam", 4);
   return wibble(_pipe);
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__echo__multiple_echos_in_a_pipeline.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__echo__multiple_echos_in_a_pipeline.snap
@@ -19,9 +19,10 @@ pub fn wibble(n) { n }
 ----- COMPILED JAVASCRIPT
 import * as $stdlib$dict from "../../gleam_stdlib/gleam/dict.mjs";
 import {
-  toList,
   Empty as $Empty,
+  List$Empty$const as $List$Empty$const,
   NonEmpty as $NonEmpty,
+  prepend as listPrepend,
   CustomType as $CustomType,
   bitArraySlice,
   bitArraySliceToInt,
@@ -35,7 +36,7 @@ export function wibble(n) {
 }
 
 export function main() {
-  let _pipe = toList([1, 2, 3]);
+  let _pipe = listPrepend(1, listPrepend(2, listPrepend(3, $List$Empty$const)));
   echo(_pipe, undefined, "src/module.gleam", 4);
   let _pipe$1 = wibble(_pipe);
   echo(_pipe$1, undefined, "src/module.gleam", 6);

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__two_pipes_in_a_row.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__two_pipes_in_a_row.snap
@@ -14,7 +14,11 @@ pub fn main() {
 
 
 ----- COMPILED JAVASCRIPT
-import { toList, CustomType as $CustomType } from "../gleam.mjs";
+import {
+  List$Empty$const as $List$Empty$const,
+  prepend as listPrepend,
+  CustomType as $CustomType,
+} from "../gleam.mjs";
 
 export class Function extends $CustomType {
   constructor($0) {
@@ -27,14 +31,17 @@ export const Function$isFunction = (value) => value instanceof Function;
 export const Function$Function$0 = (value) => value[0];
 
 export function main() {
-  return toList([
+  return listPrepend(
     (() => {
       let _pipe = () => { return 1; };
       return new Function(_pipe);
     })(),
-    (() => {
-      let _pipe = () => { return 2; };
-      return new Function(_pipe);
-    })(),
-  ]);
+    listPrepend(
+      (() => {
+        let _pipe = () => { return 2; };
+        return new Function(_pipe);
+      })(),
+      $List$Empty$const,
+    ),
+  );
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__equality.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__equality.snap
@@ -11,9 +11,13 @@ pub fn go() {
 
 
 ----- COMPILED JAVASCRIPT
-import { toList, Empty as $Empty } from "../gleam.mjs";
+import {
+  Empty as $Empty,
+  List$Empty$const as $List$Empty$const,
+  prepend as listPrepend,
+} from "../gleam.mjs";
 
 export function go() {
-  toList([1]) instanceof $Empty;
-  return !(toList([1]) instanceof $Empty);
+  listPrepend(1, $List$Empty$const) instanceof $Empty;
+  return !(listPrepend(1, $List$Empty$const) instanceof $Empty);
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__list_constants.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__list_constants.snap
@@ -9,8 +9,11 @@ pub const b = [1, 2, 3]
 
 
 ----- COMPILED JAVASCRIPT
-import { toList, List$Empty$const as $List$Empty$const } from "../gleam.mjs";
+import { List$Empty$const as $List$Empty$const, prepend as listPrepend } from "../gleam.mjs";
 
 export const a = $List$Empty$const;
 
-export const b = /* @__PURE__ */ toList([1, 2, 3]);
+export const b = /* @__PURE__ */ listPrepend(
+  1,
+  listPrepend(2, listPrepend(3, $List$Empty$const)),
+);

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__list_literals.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__list_literals.snap
@@ -13,11 +13,11 @@ pub fn go(x) {
 
 
 ----- COMPILED JAVASCRIPT
-import { toList, List$Empty$const as $List$Empty$const, prepend as listPrepend } from "../gleam.mjs";
+import { List$Empty$const as $List$Empty$const, prepend as listPrepend } from "../gleam.mjs";
 
 export function go(x) {
   $List$Empty$const;
-  toList([1]);
-  toList([1, 2]);
+  listPrepend(1, $List$Empty$const);
+  listPrepend(1, listPrepend(2, $List$Empty$const));
   return listPrepend(1, listPrepend(2, x));
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__long_list_is_generated_using_to_list_function.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__long_list_is_generated_using_to_list_function.snap
@@ -1,0 +1,17 @@
+---
+source: compiler-core/src/javascript/tests/lists.rs
+expression: "\npub fn list() {\n  [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]\n}\n"
+---
+----- SOURCE CODE
+
+pub fn list() {
+  [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+}
+
+
+----- COMPILED JAVASCRIPT
+import { toList } from "../gleam.mjs";
+
+export function list() {
+  return toList([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__long_list_literals.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__long_list_literals.snap
@@ -11,14 +11,15 @@ pub fn go() {
 
 
 ----- COMPILED JAVASCRIPT
-import { toList } from "../gleam.mjs";
+import { List$Empty$const as $List$Empty$const, prepend as listPrepend } from "../gleam.mjs";
 
 export function go() {
-  toList([
+  listPrepend(
     111111111111111111111111111111111111111111111111111111111111111111111111,
-  ]);
-  return toList([
+    $List$Empty$const,
+  );
+  return listPrepend(
     11111111111111111111111111111111111111111111,
-    1111111111111111111111111111111111111111111,
-  ]);
+    listPrepend(1111111111111111111111111111111111111111111, $List$Empty$const),
+  );
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__multi_line_list_literals.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__lists__multi_line_list_literals.snap
@@ -10,13 +10,14 @@ pub fn go(x) {
 
 
 ----- COMPILED JAVASCRIPT
-import { toList } from "../gleam.mjs";
+import { List$Empty$const as $List$Empty$const, prepend as listPrepend } from "../gleam.mjs";
 
 export function go(x) {
-  return toList([
+  return listPrepend(
     (() => {
       true;
       return 1;
     })(),
-  ]);
+    $List$Empty$const,
+  );
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__sourcemaps__sourcemap_with_list.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__sourcemaps__sourcemap_with_list.snap
@@ -10,10 +10,10 @@ expression: "\npub fn go(x) {\n  [1, 2, 3]\n}\n"
 
 ----- COMPILED JAVASCRIPT
 0 |//# sourceMappingURL=mod.mjs.map
-1 |import { toList } from "../gleam.mjs";
+1 |import { List$Empty$const as $List$Empty$const, prepend as listPrepend } from "../gleam.mjs";
 2 |
 3 |export function go(x) {
-4 |  return toList([1, 2, 3]);
+4 |  return listPrepend(1, listPrepend(2, listPrepend(3, $List$Empty$const)));
 5 |}
 
 ----- SOURCE MAP
@@ -25,7 +25,7 @@ Mappings:
 
 ⏷
 //# sourceMappingURL=mod.mjs.map
-import { toList } from "../gleam.mjs";
+import { List$Empty$const as $List$Empty$const, prepend as listPrepend } from "../gleam.mjs";
 
 
 ----- 
@@ -37,20 +37,20 @@ export function go(x) {
 ----- 
 [
 ⏷
-return toList([
+return listPrepend(
 ----- 
 1, 
 ⏷
-1, 
+1, listPrepend(
 ----- 
 2, 
 ⏷
-2, 
+2, listPrepend(
 ----- 
 3]
 }
 ⏷
-3]);
+3, $List$Empty$const)));
 }
 ----- 
 


### PR DESCRIPTION
We already did that for lists with a tail, now we do it for all lists. This proves to be quite more efficient