### PR TITLE
fix capture syntax elimination logic in formatting #6240

### DIFF
--- a/format/src/lib.rs
+++ b/format/src/lib.rs
@@ -2078,6 +2078,13 @@ impl<'a, 'doc> Formatter<'a> {
             panic!("Function capture body found not to be a call in the formatter")
         };
 
+        let flag = match &**fun {
+            UntypedExpr::Fn {arguments, .. } =>
+                arguments.iter().any(|a| a.is_capture_hole()),
+            UntypedExpr::Var { .. } => true,
+            _ => false
+        };
+
         match (position, arguments.as_slice()) {
             // The capture has a single unlabelled hole:
             //
@@ -2092,7 +2099,9 @@ impl<'a, 'doc> Formatter<'a> {
             (
                 FnCapturePosition::RightHandSideOfPipe | FnCapturePosition::EverywhereElse,
                 [argument],
-            ) if argument.is_capture_hole() && argument.label.is_none() => self.expr(arena, fun),
+            ) if argument.is_capture_hole() && argument.label.is_none() &&
+                flag
+                => self.expr(arena, fun),
 
             // The capture is on the right hand side of a pipe and its first
             // argument it an unlabelled capture hole:

--- a/format/src/tests.rs
+++ b/format/src/tests.rs
@@ -3673,6 +3673,17 @@ fn function_captures_test() {
 }
 "
     );
+
+    assert_format_rewrite!(
+        "pub fn main() {
+  run()(_)
+}
+",
+        "pub fn main() {
+  run()(_)
+}
+"
+    );
 }
 
 #[test]


### PR DESCRIPTION
- [ ] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [x] Tests have been added for new behaviour
- [ ] The changelog has been updated for any user-facing changes

Fixes #6240

Hello! I've encountered a bug where the formatter removes the capture syntax, and I have opened Issue #6240 for this. 

I haven't received a reply on the issue yet, but I went ahead and created this PR because I already figured out the fix and wanted to provide a concrete code to discuss.

I haven't updated the CHANGELOG.md yet because I wasn't sure if this fix requires an entry, or how you prefer to format it. Please let me know if I should add it!