### PR TITLE
Add warnings for immediately called anonymous functions and captures

### DIFF
--- a/compiler-core/src/type_/error.rs
+++ b/compiler-core/src/type_/error.rs
@@ -1234,6 +1234,28 @@ pub enum Warning {
     PipeIntoCallWhichReturnsFunction {
         location: SrcSpan,
     },
+
+    /// When an anonymous function is immediately called, which can be replaced
+    /// with a block expression or direct let bindings:
+    ///
+    /// ```gleam
+    /// fn(a, b) { a + b }(1, 2)
+    /// ```
+    ///
+    ImmediatelyCalledAnonymousFunction {
+        location: SrcSpan,
+    },
+
+    /// When a function capture is immediately called, which can be replaced
+    /// with a direct function call:
+    ///
+    /// ```gleam
+    /// add(1, _)(10)
+    /// ```
+    ///
+    ImmediatelyCalledFunctionCapture {
+        location: SrcSpan,
+    },
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
@@ -1507,7 +1529,9 @@ impl Warning {
             | Warning::RedundantComparison { location, .. }
             | Warning::JavaScriptBitArrayUnsafeInt { location, .. }
             | Warning::UnusedRecursiveArgument { location, .. }
-            | Warning::PipeIntoCallWhichReturnsFunction { location } => *location,
+            | Warning::PipeIntoCallWhichReturnsFunction { location }
+            | Warning::ImmediatelyCalledAnonymousFunction { location, .. }
+            | Warning::ImmediatelyCalledFunctionCapture { location, .. } => *location,
         }
     }
 

--- a/compiler-core/src/type_/expression.rs
+++ b/compiler-core/src/type_/expression.rs
@@ -1230,6 +1230,20 @@ impl<'a, 'b> ExprTyper<'a, 'b> {
             });
         }
 
+        // When an anonymous function or a function capture is immediately called
+        // we want to warn the user because they could use a simpler form.
+        // e.g. `fn(a) { a + 1 }(1)` could be `{ let a = 1; a + 1 }`
+        // e.g. `add(1, _)(10)` could be `add(1, 10)`
+        if let TypedExpr::Fn { kind, .. } = &fun {
+            if kind.is_anonymous() {
+                self.problems
+                    .warning(Warning::ImmediatelyCalledAnonymousFunction { location });
+            } else if kind.is_capture() {
+                self.problems
+                    .warning(Warning::ImmediatelyCalledFunctionCapture { location });
+            }
+        }
+
         self.purity = self.purity.merge(fun.called_function_purity());
 
         TypedExpr::Call {

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__deprecated_value_in_nested_use_with_fn_literal_rhs_warns_once.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__deprecated_value_in_nested_use_with_fn_literal_rhs_warns_once.snap
@@ -17,6 +17,33 @@ pub fn main() {
 
 
 ----- WARNING
+warning: Immediately called anonymous function
+   ┌─ /src/warning/wrn.gleam:8:3
+   │  
+ 8 │ ╭   use <- fn(f) { f() }
+ 9 │ │   use <- fn(f) { f() }
+10 │ │   wibble()
+   │ ╰──────────^ This anonymous function is immediately called
+
+This anonymous function is immediately called. It can be replaced with a
+block expression.
+
+Hint: Use a block expression with `let` bindings instead, for example: `{
+let a = 1; let b = 2; a + b }`
+
+warning: Immediately called anonymous function
+   ┌─ /src/warning/wrn.gleam:9:3
+   │  
+ 9 │ ╭   use <- fn(f) { f() }
+10 │ │   wibble()
+   │ ╰──────────^ This anonymous function is immediately called
+
+This anonymous function is immediately called. It can be replaced with a
+block expression.
+
+Hint: Use a block expression with `let` bindings instead, for example: `{
+let a = 1; let b = 2; a + b }`
+
 warning: Deprecated value used
    ┌─ /src/warning/wrn.gleam:10:3
    │

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__deprecated_value_in_use_with_fn_literal_rhs_warns_once.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__deprecated_value_in_use_with_fn_literal_rhs_warns_once.snap
@@ -16,6 +16,19 @@ pub fn main() {
 
 
 ----- WARNING
+warning: Immediately called anonymous function
+  ┌─ /src/warning/wrn.gleam:8:3
+  │  
+8 │ ╭   use <- fn(f) { f() }
+9 │ │   wibble()
+  │ ╰──────────^ This anonymous function is immediately called
+
+This anonymous function is immediately called. It can be replaced with a
+block expression.
+
+Hint: Use a block expression with `let` bindings instead, for example: `{
+let a = 1; let b = 2; a + b }`
+
 warning: Deprecated value used
   ┌─ /src/warning/wrn.gleam:9:3
   │

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__immediately_called_anonymous_function.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__immediately_called_anonymous_function.snap
@@ -1,0 +1,23 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main() {\n  fn(a, b) { a + b }(1, 2)\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  fn(a, b) { a + b }(1, 2)
+}
+
+
+----- WARNING
+warning: Immediately called anonymous function
+  ┌─ /src/warning/wrn.gleam:3:3
+  │
+3 │   fn(a, b) { a + b }(1, 2)
+  │   ^^^^^^^^^^^^^^^^^^^^^^^^ This anonymous function is immediately called
+
+This anonymous function is immediately called. It can be replaced with a
+block expression.
+
+Hint: Use a block expression with `let` bindings instead, for example: `{
+let a = 1; let b = 2; a + b }`

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__immediately_called_anonymous_function_with_single_arg.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__immediately_called_anonymous_function_with_single_arg.snap
@@ -1,0 +1,23 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn main() {\n  fn(x) { x + 1 }(5)\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main() {
+  fn(x) { x + 1 }(5)
+}
+
+
+----- WARNING
+warning: Immediately called anonymous function
+  ┌─ /src/warning/wrn.gleam:3:3
+  │
+3 │   fn(x) { x + 1 }(5)
+  │   ^^^^^^^^^^^^^^^^^^ This anonymous function is immediately called
+
+This anonymous function is immediately called. It can be replaced with a
+block expression.
+
+Hint: Use a block expression with `let` bindings instead, for example: `{
+let a = 1; let b = 2; a + b }`

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__immediately_called_function_capture.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__immediately_called_function_capture.snap
@@ -1,0 +1,21 @@
+---
+source: compiler-core/src/type_/tests/warnings.rs
+expression: "\npub fn add(a, b) { a + b }\npub fn main() {\n  add(1, _)(10)\n}\n"
+---
+----- SOURCE CODE
+
+pub fn add(a, b) { a + b }
+pub fn main() {
+  add(1, _)(10)
+}
+
+
+----- WARNING
+warning: Immediately called function capture
+  ┌─ /src/warning/wrn.gleam:4:3
+  │
+4 │   add(1, _)(10)
+  │   ^^^^^^^^^^^^^ This function capture is immediately called
+
+This function capture is immediately called. It can be replaced with a
+direct function call.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__impure_fn_function_call_not_mark_as_unused.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__impure_fn_function_call_not_mark_as_unused.snap
@@ -1,11 +1,11 @@
 ---
 source: compiler-core/src/type_/tests/warnings.rs
-expression: "\npub fn main() {\n    fn(a) { a + 1 }(1)\n    Nil\n}\n"
+expression: "\npub fn main() {\n    fn(_) { panic }(1)\n    Nil\n}\n"
 ---
 ----- SOURCE CODE
 
 pub fn main() {
-    fn(a) { a + 1 }(1)
+    fn(_) { panic }(1)
     Nil
 }
 
@@ -14,7 +14,7 @@ pub fn main() {
 warning: Immediately called anonymous function
   ┌─ /src/warning/wrn.gleam:3:5
   │
-3 │     fn(a) { a + 1 }(1)
+3 │     fn(_) { panic }(1)
   │     ^^^^^^^^^^^^^^^^^^ This anonymous function is immediately called
 
 This anonymous function is immediately called. It can be replaced with a
@@ -22,13 +22,3 @@ block expression.
 
 Hint: Use a block expression with `let` bindings instead, for example: `{
 let a = 1; let b = 2; a + b }`
-
-warning: Unused value
-  ┌─ /src/warning/wrn.gleam:3:5
-  │
-3 │     fn(a) { a + 1 }(1)
-  │     ^^^^^^^^^^^^^^^^^^ This value is never used
-
-This expression computes a value without any side effects, but then the
-value isn't used at all. You might want to assign it to a variable, or
-delete the expression entirely if it's not needed.

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unreachable_code_in_use_with_fn_literal_rhs_warns_once.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unreachable_code_in_use_with_fn_literal_rhs_warns_once.snap
@@ -16,6 +16,20 @@ pub fn main() {
 
 
 ----- WARNING
+warning: Immediately called anonymous function
+  ┌─ /src/warning/wrn.gleam:7:3
+  │  
+7 │ ╭   use <- fn(f) { f() }
+8 │ │   panic
+9 │ │   wibble()
+  │ ╰──────────^ This anonymous function is immediately called
+
+This anonymous function is immediately called. It can be replaced with a
+block expression.
+
+Hint: Use a block expression with `let` bindings instead, for example: `{
+let a = 1; let b = 2; a + b }`
+
 warning: Unreachable code
   ┌─ /src/warning/wrn.gleam:9:3
   │

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unreachable_use_fn_statement_after_panic.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__unreachable_use_fn_statement_after_panic.snap
@@ -20,3 +20,16 @@ warning: Unreachable code
   │ ╰───^
 
 This code is unreachable because it comes after a `panic`.
+
+warning: Immediately called anonymous function
+  ┌─ /src/warning/wrn.gleam:4:3
+  │  
+4 │ ╭   use <- fn(_) { Nil }
+5 │ │   1
+  │ ╰───^ This anonymous function is immediately called
+
+This anonymous function is immediately called. It can be replaced with a
+block expression.
+
+Hint: Use a block expression with `let` bindings instead, for example: `{
+let a = 1; let b = 2; a + b }`

--- a/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__use_with_pure_fn_expression_is_marked_as_unused.snap
+++ b/compiler-core/src/type_/tests/snapshots/gleam_core__type___tests__warnings__use_with_pure_fn_expression_is_marked_as_unused.snap
@@ -27,3 +27,16 @@ warning: Unused value
 This expression computes a value without any side effects, but then the
 value isn't used at all. You might want to assign it to a variable, or
 delete the expression entirely if it's not needed.
+
+warning: Immediately called anonymous function
+  ┌─ /src/warning/wrn.gleam:4:9
+  │  
+4 │ ╭         use _ <- fn(a) { a }
+5 │ │         1
+  │ ╰─────────^ This anonymous function is immediately called
+
+This anonymous function is immediately called. It can be replaced with a
+block expression.
+
+Hint: Use a block expression with `let` bindings instead, for example: `{
+let a = 1; let b = 2; a + b }`

--- a/compiler-core/src/type_/tests/warnings.rs
+++ b/compiler-core/src/type_/tests/warnings.rs
@@ -3173,7 +3173,7 @@ pub fn main() {
 
 #[test]
 fn impure_fn_function_call_not_mark_as_unused() {
-    assert_no_warnings!(
+    assert_warning!(
         r#"
 pub fn main() {
     fn(_) { panic }(1)
@@ -5253,5 +5253,42 @@ pub fn thingy(wibble) {
   }
 }
     "#
+    );
+}
+
+// https://github.com/gleam-lang/gleam/issues/6259
+#[test]
+fn immediately_called_anonymous_function() {
+    assert_warning!(
+        r#"
+pub fn main() {
+  fn(a, b) { a + b }(1, 2)
+}
+"#
+    );
+}
+
+// https://github.com/gleam-lang/gleam/issues/6259
+#[test]
+fn immediately_called_anonymous_function_with_single_arg() {
+    assert_warning!(
+        r#"
+pub fn main() {
+  fn(x) { x + 1 }(5)
+}
+"#
+    );
+}
+
+// https://github.com/gleam-lang/gleam/issues/6258
+#[test]
+fn immediately_called_function_capture() {
+    assert_warning!(
+        r#"
+pub fn add(a, b) { a + b }
+pub fn main() {
+  add(1, _)(10)
+}
+"#
     );
 }

--- a/compiler-core/src/warning.rs
+++ b/compiler-core/src/warning.rs
@@ -1570,6 +1570,48 @@ not be used.",
                         extra_labels: vec![],
                     }),
                 },
+
+                type_::Warning::ImmediatelyCalledAnonymousFunction { location } => Diagnostic {
+                    title: "Immediately called anonymous function".into(),
+                    text: wrap(
+                        "This anonymous function is immediately called. \
+It can be replaced with a block expression.",
+                    ),
+                    hint: Some(
+                        "Use a block expression with `let` bindings instead, \
+for example: `{ let a = 1; let b = 2; a + b }`"
+                            .into(),
+                    ),
+                    level: diagnostic::Level::Warning,
+                    location: Some(Location {
+                        label: diagnostic::Label {
+                            text: Some("This anonymous function is immediately called".into()),
+                            span: *location,
+                        },
+                        path: path.clone(),
+                        src: src.clone(),
+                        extra_labels: vec![],
+                    }),
+                },
+
+                type_::Warning::ImmediatelyCalledFunctionCapture { location } => Diagnostic {
+                    title: "Immediately called function capture".into(),
+                    text: wrap(
+                        "This function capture is immediately called. \
+It can be replaced with a direct function call.",
+                    ),
+                    hint: None,
+                    level: diagnostic::Level::Warning,
+                    location: Some(Location {
+                        label: diagnostic::Label {
+                            text: Some("This function capture is immediately called".into()),
+                            span: *location,
+                        },
+                        path: path.clone(),
+                        src: src.clone(),
+                        extra_labels: vec![],
+                    }),
+                },
             },
 
             Warning::EmptyModule { path: _, name } => Diagnostic {


### PR DESCRIPTION
## Overview

Adds two new compiler warnings for immediately invoked function expressions (IIFEs), addressing both #6259 and #6258.

### #6259 — Immediately called anonymous functions

```gleam
// Before (warns)
echo fn(a, b) { a + b }(1, 2)

// Suggested replacement
echo {
  let a = 1
  let b = 2
  a + b
}
```

### #6258 — Immediately called function captures

```gleam
// Before (warns)
echo add(1, _)(10)

// Suggested replacement — call directly
echo add(1, 10)
```

## Changes

- **`type_/error.rs`** — Two new `Warning` variants: `ImmediatelyCalledAnonymousFunction` and `ImmediatelyCalledFunctionCapture`
- **`warning.rs`** — Diagnostic rendering with descriptive titles and hints
- **`type_/expression.rs`** — Detection in `infer_call()` after `do_infer_call` returns; checks if callee is `TypedExpr::Fn` with anonymous or capture kind
- **`type_/tests/warnings.rs`** — 3 new tests + 1 updated test (`impure_fn_function_call_not_mark_as_unused` now expects IIFE warning)

## Test results

3519 passed, 0 failed.
