### PR TITLE
Fixed erlang badarg error when concat'ing a single string expr block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -282,6 +282,11 @@
   `gleam deps download` would needlessly resolve versions again.
   ([John Downey](https://github.com/jtdowney))
 
+- Fixed a bug where concatenating a string to a string in a block would
+  produce an invalid bitstring on the Erlang target.
+  ([Lillian Rose](https://github.com/lillianrubyrose) with
+  [Mar Bloeiman](https://github.com/strawmelonjuice))
+
 ## v1.18.1 - 2026-08-01
 
 - Fixed a bug where the Erlang code generator would generate wrong code when

--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -3662,6 +3662,12 @@ fn produces_literal_string(value: &TypedExpr) -> bool {
                 },
             ..
         } => constant_produces_literal_string(literal),
+        TypedExpr::Block { statements, .. }
+            if statements.len() == 1
+                && let Statement::Expression(expression) = statements.first() =>
+        {
+            produces_literal_string(expression)
+        }
 
         TypedExpr::Int { .. }
         | TypedExpr::Var { .. }

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__concat_with_block_with_multiple_expr.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__concat_with_block_with_multiple_expr.snap
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/erlang/tests/strings.rs
+expression: "\npub fn concat(name) {\n  name <> {\n    let x = \"/\"\n    x\n  } <> name\n}\n"
+---
+----- SOURCE CODE
+
+pub fn concat(name) {
+  name <> {
+    let x = "/"
+    x
+  } <> name
+}
+
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_ignored, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
+-export([concat/1]).
+
+-spec concat(binary()) -> binary().
+concat(Name) ->
+    <<<<Name/binary, (begin
+        X = ~"/",
+        X
+    end)/binary>>/binary, Name/binary>>.

--- a/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__concat_with_block_with_single_string_expr.snap
+++ b/compiler-core/src/erlang/tests/snapshots/gleam_core__erlang__tests__strings__concat_with_block_with_single_string_expr.snap
@@ -1,0 +1,19 @@
+---
+source: compiler-core/src/erlang/tests/strings.rs
+expression: "\npub fn concat(name) {\n  name <> { \"/\" } <> name\n}\n"
+---
+----- SOURCE CODE
+
+pub fn concat(name) {
+  name <> { "/" } <> name
+}
+
+
+----- COMPILED ERLANG
+-module(my@mod).
+-compile([no_auto_import, nowarn_ignored, nowarn_unused_vars, nowarn_unused_function, nowarn_nomatch, inline]).
+-export([concat/1]).
+
+-spec concat(binary()) -> binary().
+concat(Name) ->
+    <<<<Name/binary, "/"/utf8>>/binary, Name/binary>>.

--- a/compiler-core/src/erlang/tests/strings.rs
+++ b/compiler-core/src/erlang/tests/strings.rs
@@ -495,3 +495,14 @@ pub fn main() {
 "#
     );
 }
+
+#[test]
+fn concat_with_block_with_single_string_expr() {
+    assert_erl!(
+        r#"
+pub fn concat(name) {
+  name <> { "/" } <> name
+}
+"#,
+    );
+}

--- a/compiler-core/src/erlang/tests/strings.rs
+++ b/compiler-core/src/erlang/tests/strings.rs
@@ -506,3 +506,17 @@ pub fn concat(name) {
 "#,
     );
 }
+
+#[test]
+fn concat_with_block_with_multiple_expr() {
+    assert_erl!(
+        r#"
+pub fn concat(name) {
+  name <> {
+    let x = "/"
+    x
+  } <> name
+}
+"#,
+    );
+}

--- a/test/language/test/language/string_test.gleam
+++ b/test/language/test/language/string_test.gleam
@@ -1,16 +1,41 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2026 The Gleam contributors
 
+fn id(string: String) -> String {
+  string
+}
+
 pub fn empty_strings_equal_test() {
-  assert "" == ""
+  assert id("") == id("")
 }
 
 pub fn newlines_equal_test() {
-  assert "
-" == "\n"
+  assert id(
+      "
+",
+    )
+    == id("\n")
 }
 
 pub fn let_assert_string_prefix_test() {
   let assert "ab" <> rest = "abcdef"
   assert "cdef" == rest
+}
+
+pub fn concat_block_single_test() {
+  let name = id("Lucy")
+  let result = name <> { "/" } <> name
+  assert result == "Lucy/Lucy"
+}
+
+pub fn concat_block_multiple_test() {
+  let name = id("Lucy")
+  let result =
+    name
+    <> {
+      let x = "/"
+      x
+    }
+    <> name
+  assert result == "Lucy/Lucy"
 }


### PR DESCRIPTION
Fixes #6272.

- [x] The changes in this PR have been discussed beforehand in an issue
> Well, so far it's a monologue xD, but the issue is there yes.
- [x] The issue for this PR has been linked
> <https://github.com/gleam-lang/gleam/issues/6272> :)
- [x] Tests have been added for new behaviour
> There's a test for a bug fix, not exactly new behaviour, but it's new proper behaviour and now tested!
- [x] The changelog has been updated for any user-facing changes
> It has!
