### PR TITLE
Fix compiler capture bug

### DIFF
--- a/compiler-core/src/erlang.rs
+++ b/compiler-core/src/erlang.rs
@@ -7,7 +7,10 @@ mod tests;
 
 use crate::build::Target;
 use crate::erlang::pattern::{AliasedLiteral, PatternGenerator};
+use crate::exhaustiveness::CompiledCase;
+use crate::inline::InlinableValueConstructor::LocalVariable;
 use crate::strings::to_snake_case;
+use crate::type_::error::VariableOrigin;
 use crate::type_::{self, is_prelude_module};
 use crate::{
     ast::*,
@@ -918,12 +921,63 @@ impl<'a, 'generator> FunctionGenerator<'a, 'generator> {
                 self.call(builder, constructor, arguments);
             }
 
+            TypedExpr::Fn {
+                location, arguments, body, kind: FunctionLiteralKind::Capture { .. }, ..
+            } => {
+                if let Statement::Expression(TypedExpr::Call { fun , /*arguments: inner_arguments*/ .. }) = body.first()
+                    && body.len() == 1
+                    && (
+                        matches!(&**fun, TypedExpr::Call { .. })
+                        || matches!(&**fun, TypedExpr::TupleIndex { .. })
+                        || matches!(&**fun, TypedExpr::RecordAccess{ .. })
+                    )
+                {
+                    // {
+                    //   let x = <Expr> // evaluate first
+                    //   fn(a) { x(a) }
+                    // }
+
+                    let block = builder.start_block();
+
+                    let tmp_val_name = self.new_erlang_variable("Tmp", location.clone());
+                    builder.match_operator();
+                    builder.variable_pattern(&tmp_val_name);
+
+                    self.expression(builder, fun);
+
+                    let argument_names = self.function_arguments_names(arguments, false).collect::<Vec<_>>();
+                    let function = builder.start_anonymous_function(argument_names.clone());
+                    let call = builder.start_call();
+                    builder.variable(&tmp_val_name);
+                    let call = builder.end_called_expression(call);
+                    for argument in argument_names {
+                        builder.variable(&argument);
+                    }
+                    builder.end_call(call);
+                    builder.end_function(function);
+                    builder.end_block(block);
+                } else {
+                    // ```
+                    // fn(x) { <Expr>(x) }
+                    // ```
+                    let outer_scope = self.taken_names.clone();
+                    let argument_names = self.function_arguments_names(arguments, false);
+                    let function = builder.start_anonymous_function(argument_names);
+                    self.statement_sequence(builder, body);
+                    builder.end_function(function);
+                    self.taken_names = outer_scope;
+                }
+            }
+
             //
             // All kinds of anonymous functions.
             //
             TypedExpr::Fn {
-                arguments, body, ..
+                arguments, body, kind: FunctionLiteralKind::Use { .. } | FunctionLiteralKind::Anonymous { .. }, ..
             } => {
+                // ```
+                // fn(x) { <Expr>(x) }
+                // ```
                 let outer_scope = self.taken_names.clone();
                 let argument_names = self.function_arguments_names(arguments, false);
                 let function = builder.start_anonymous_function(argument_names);

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -1979,6 +1979,85 @@ impl<'module, 'a, 'doc> Generator<'module, 'a, 'doc> {
         body: &'a [TypedStatement],
         kind: &FunctionLiteralKind,
     ) -> Document<'a, 'doc> {
+        if let Some(Statement::Expression(TypedExpr::Call { location, fun , /*arguments: inner_arguments*/ .. })) = body.first()
+            && body.len() == 1
+            && (
+                matches!(&**fun, TypedExpr::Call { .. })
+                || matches!(&**fun, TypedExpr::TupleIndex { .. })
+                || matches!(&**fun, TypedExpr::RecordAccess{ .. })
+            ) {
+            let local_tmp_value= "tmp".into();
+            let local_tmp_value = self.next_local_var(&local_tmp_value);
+            let local_capture_value = CAPTURE_VARIABLE.into();
+            let local_capture_value = self.next_local_var(&local_capture_value);
+
+            let subject = self.expression(arena, fun);
+
+            // let tmp = <expr>;
+            let assignment = docvec![
+                arena,
+                self.source_map_tracker(arena, location.start),
+                LET_SPACE_DOCUMENT,
+                local_tmp_value.clone(),
+                SPACE_EQUAL_SPACE_DOCUMENT,
+                subject,
+                SEMICOLON_DOCUMENT,
+                BREAKABLE_SPACE_DOCUMENT,
+            ];
+
+            // return (x) => { tmp(x) };
+            let return_assignment_contents = docvec![
+                arena,
+                RETURN_SPACE_DOCUMENT,
+                OPEN_PAREN_DOCUMENT,
+                local_capture_value.clone(),
+                CLOSE_PAREN_DOCUMENT,
+                SPACE_EQUAL_ARROW_SPACE_OPEN_CURLY_DOCUMENT,
+                BREAKABLE_SPACE_DOCUMENT,
+                local_tmp_value,
+                OPEN_PAREN_DOCUMENT,
+                local_capture_value,
+                CLOSE_PAREN_DOCUMENT,
+            ];
+            let return_assignment = docvec![
+                arena,
+                return_assignment_contents
+                    .nest(arena, INDENT)
+                    .append(arena, BREAKABLE_SPACE_DOCUMENT)
+                    .group(arena),
+                CLOSE_CURLY_DOCUMENT,
+                SEMICOLON_DOCUMENT,
+            ];
+
+            let block_contents = docvec![
+                arena,
+                OPEN_PAREN_DOCUMENT,
+                OPEN_PAREN_DOCUMENT,
+                CLOSE_PAREN_DOCUMENT,
+                SPACE_EQUAL_ARROW_SPACE_OPEN_CURLY_DOCUMENT,
+                BREAKABLE_SPACE_DOCUMENT,
+                assignment,
+                return_assignment,
+            ];
+
+            // (() => {
+            //   let tmp = <expr>;
+            //   return (x) => tmp(x);
+            // })()
+            let docs = docvec![
+                arena,
+                block_contents
+                    .nest(arena, INDENT)
+                    .append(arena, BREAKABLE_SPACE_DOCUMENT)
+                    .group(arena),
+                CLOSE_CURLY_DOCUMENT,
+                CLOSE_PAREN_DOCUMENT,
+                OPEN_PAREN_DOCUMENT,
+                CLOSE_PAREN_DOCUMENT,
+            ];
+            return docs;
+        }
+
         // New function, this is now the tail position
         let function_position = std::mem::replace(&mut self.function_position, Position::Tail);
         let scope_position = std::mem::replace(&mut self.scope_position, Position::Tail);

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -1985,7 +1985,8 @@ impl<'module, 'a, 'doc> Generator<'module, 'a, 'doc> {
                 matches!(&**fun, TypedExpr::Call { .. })
                 || matches!(&**fun, TypedExpr::TupleIndex { .. })
                 || matches!(&**fun, TypedExpr::RecordAccess{ .. })
-            ) {
+            )
+            && matches!(kind, FunctionLiteralKind::Capture{ .. }) {
             let local_tmp_value= "tmp".into();
             let local_tmp_value = self.next_local_var(&local_tmp_value);
             let local_capture_value = CAPTURE_VARIABLE.into();


### PR DESCRIPTION
- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked
- [ ] Tests have been added for new behaviour
- [ ] The changelog has been updated for any user-facing changes

Related issue #6242

The following code:

```gleam
  let v = func()(_)
```

now compiles to:

## Erlang

```erlang
    V = begin
        Tmp = Func(),
        fun(_capture) ->
            Tmp(_capture)
        end
    end,
```

## Javascript

```js
  let v = (() => { let tmp = func(); return (_capture) => { tmp(_capture) }; })();
```

## Summary of Changes

When compiling capture expressions, the code generators (both Erlang and JavaScript) now eagerly evaluate the target expression if it matches any of the following:

- Function calls (`TypedExpr::Call`)
- Record field accesses (`TypedExpr::RecordAccess`)
- Tuple index accesses (`TypedExpr::TupleIndex`)

In these cases, code conceptually equivalent to the following is generated:

```gleam
{
    let tmp = <expr>
    fn (x) { tmp(x) }
}
```