### PR TITLE
Add issue link format suggestion to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,5 @@
-Fixes #
+Closes #ISSUE_NUMBER_HERE
+
 - [ ] The changes in this PR have been discussed beforehand in an issue
 - [ ] The issue for this PR has been linked above
 - [ ] Tests have been added for new behaviour

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,5 @@
+Fixes #
 - [ ] The changes in this PR have been discussed beforehand in an issue
-- [ ] The issue for this PR has been linked
+- [ ] The issue for this PR has been linked above
 - [ ] Tests have been added for new behaviour
 - [ ] The changelog has been updated for any user-facing changes


### PR DESCRIPTION
Since GitHub only understands a PR as closing an issue if it's in the format "Fixes #xxxx", "Closes #xxxx", etc, hopefully this will guide people into using the correct keyword to make sure issues are properly closed once relevant PRs are merged.