### PR TITLE
Do not emit unneeded loop variables in tail-recursive functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,10 @@
 
   ([Andrey Kozhev](https://github.com/ankddev))
 
+- The compiler now generates slightly smaller code for tail-recursive functions
+  JavaScript target.
+  ([rebecca](https://tangled.org/becca.monster))
+
 ### Build tool
 
 - The build tool now stores its build cache in a more compact binary format,

--- a/compiler-core/src/javascript.rs
+++ b/compiler-core/src/javascript.rs
@@ -1235,7 +1235,9 @@ impl<'a, 'doc> Generator<'a> {
             fun_arguments(
                 arena,
                 function.arguments.as_slice(),
-                generator.tail_recursion_used
+                generator
+                    .tail_recursion_used
+                    .then_some(&generator.loop_variable_arguments),
             ),
             SPACE_OPEN_CURLY_DOCUMENT,
             docvec![arena, LINE_DOCUMENT, body]
@@ -1394,14 +1396,15 @@ fn create_cursor_position_observer<'a, 'doc>(
 fn fun_arguments<'a, 'doc>(
     arena: &'doc DocumentArena<'a, 'doc>,
     arguments: &'a [TypedArg],
-    tail_recursion_used: bool,
+    loop_variable_arguments: Option<&HashSet<usize>>,
 ) -> Document<'a, 'doc> {
     let mut discards = 0;
     wrap_arguments(
         arena,
         arguments
             .iter()
-            .map(|argument| match argument.get_variable_name() {
+            .enumerate()
+            .map(|(index, argument)| match argument.get_variable_name() {
                 None => {
                     let doc = if discards == 0 {
                         UNDERSCORE_DOCUMENT
@@ -1411,7 +1414,12 @@ fn fun_arguments<'a, 'doc>(
                     discards += 1;
                     doc
                 }
-                Some(name) if tail_recursion_used => eco_format!("loop${name}").to_doc(arena),
+                Some(name)
+                    if loop_variable_arguments
+                        .is_some_and(|arguments| arguments.contains(&index)) =>
+                {
+                    eco_format!("loop${name}").to_doc(arena)
+                }
                 Some(name) => maybe_escape_identifier(name).to_doc(arena),
             }),
     )

--- a/compiler-core/src/javascript/expression.rs
+++ b/compiler-core/src/javascript/expression.rs
@@ -6,13 +6,15 @@ use vec1::Vec1;
 
 use super::{decision::ASSIGNMENT_VAR, *};
 use crate::{
-    ast::*,
+    ast::{visit, *},
     exhaustiveness::StringEncoding,
     type_::{
         ModuleValueConstructor, Type, TypedCallArg, ValueConstructor, ValueConstructorVariant,
+        error::{VariableDeclaration, VariableOrigin},
     },
 };
 use pretty_arena::*;
+use std::collections::HashSet;
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
@@ -118,6 +120,157 @@ enum CurrentFunction {
     /// }
     /// ```
     Anonymous,
+}
+
+/// A visitor collecting all variables needing a loop assignment
+/// inside a tail-recursive function.
+struct FunctionParameterReferences<'a> {
+    /// The function we are currently analysing
+    function_name: &'a EcoString,
+    /// `true` if we are inside a nested anonymous function
+    inside_function_expression: bool,
+    /// `true` if we are inside a call to the function being analysed
+    inside_call_arguments: bool,
+    /// During a call, keeps track of all parameters that have been reassigned already
+    reassigned_parameters: HashSet<usize>,
+    /// The final collection of all parameters that are unsafe to mutate directly
+    loop_variable_arguments: HashSet<usize>,
+}
+
+impl FunctionParameterReferences<'_> {
+    pub fn collect(function_name: &EcoString, body: &[TypedStatement]) -> HashSet<usize> {
+        let mut visitor = FunctionParameterReferences {
+            function_name,
+            inside_function_expression: false,
+            inside_call_arguments: false,
+            reassigned_parameters: HashSet::new(),
+            loop_variable_arguments: HashSet::new(),
+        };
+
+        for statement in body {
+            visit::Visit::visit_typed_statement(&mut visitor, statement);
+        }
+
+        visitor.loop_variable_arguments
+    }
+
+    fn record_parameter_access(&mut self, index: usize) {
+        // A parameter becomes unsafe to mutate if we either capture it within
+        // the body of an anonymous function, or if during a call we already
+        // would've reassigned it.
+        if self.inside_function_expression || self.reassigned_parameters.contains(&index) {
+            let _ = self.loop_variable_arguments.insert(index);
+        }
+    }
+}
+
+impl<'ast> visit::Visit<'ast> for FunctionParameterReferences<'_> {
+    fn visit_typed_expr(&mut self, expression: &'ast TypedExpr) {
+        let previously_inside_function_expression = self.inside_function_expression;
+
+        // If we are inside a function expression, we have to assume that any argument
+        // captured might escape the current scope or loop iteration.
+        self.inside_function_expression |= matches!(expression, TypedExpr::Fn { .. });
+
+        // If the expression we're visiting is a reference to one of our
+        // parameters, record it as visited.
+        if let Some(index) = expression_parameter_index(self.function_name, expression) {
+            self.record_parameter_access(index);
+        }
+
+        // If we are looking at a call to this function, assume it might be
+        // a tail call and mark parameters we use out-of-order as unsafe
+        // to mutate.
+        //
+        // This is not as accurate as it could be, we could instead scan at
+        // every tail-call site (where we also know it is in fact a tail call),
+        // checking which variables are actually reassigned in an unsafe way.
+        // This turned out to not justify its added complexity as its potential
+        // gains are offset by needing a separate variable for each tail call.
+        if !self.inside_function_expression
+            && !self.inside_call_arguments
+            && let TypedExpr::Call { fun, arguments, .. } = expression
+            && let Some((constructor, referenced_name)) = fun.var_constructor()
+            && let ValueConstructorVariant::ModuleFn { .. } = &constructor.variant
+            && referenced_name == self.function_name
+        {
+            // Only top-level calls can be tail-calls.
+            self.inside_call_arguments = true;
+            for (index, argument) in arguments.iter().enumerate() {
+                self.visit_typed_expr(&argument.value);
+
+                // If a parameter is just passed through unchanged, we don't need
+                // to track it as "reassigned" or mutated
+                if !is_unchanged_argument(self.function_name, &argument.value, index) {
+                    // For all others, we collect them here so that when we visit
+                    // the next argument expression up above and encounter it
+                    // again, we can mark it as needing a loop binding.
+                    let _ = self.reassigned_parameters.insert(index);
+                }
+            }
+            self.reassigned_parameters.clear();
+            self.inside_call_arguments = false;
+        } else {
+            visit::visit_typed_expr(self, expression);
+        }
+
+        self.inside_function_expression = previously_inside_function_expression;
+    }
+
+    fn visit_typed_clause_guard(&mut self, guard: &'ast TypedClauseGuard) {
+        if let ClauseGuard::Var { origin, .. } = guard
+            && let Some(index) = function_parameter_index(self.function_name, origin)
+        {
+            self.record_parameter_access(index);
+        }
+
+        visit::visit_typed_clause_guard(self, guard);
+    }
+
+    fn visit_typed_pattern_bit_array_size(&mut self, size: &'ast TypedBitArraySize) {
+        if let BitArraySize::Variable {
+            constructor: Some(constructor),
+            ..
+        } = size
+            && let ValueConstructorVariant::LocalVariable { origin, .. } = &constructor.variant
+            && let Some(index) = function_parameter_index(self.function_name, origin)
+        {
+            self.record_parameter_access(index);
+        }
+
+        visit::visit_typed_pattern_bit_array_size(self, size);
+    }
+}
+
+fn function_parameter_index(function_name: &EcoString, origin: &VariableOrigin) -> Option<usize> {
+    match &origin.declaration {
+        VariableDeclaration::FunctionParameter {
+            function_name: Some(declaring_function),
+            index,
+        } if declaring_function == function_name => Some(*index),
+
+        VariableDeclaration::LetPattern
+        | VariableDeclaration::UsePattern
+        | VariableDeclaration::ClausePattern
+        | VariableDeclaration::FunctionParameter { .. }
+        | VariableDeclaration::Generated => None,
+    }
+}
+
+fn expression_parameter_index(function_name: &EcoString, expression: &TypedExpr) -> Option<usize> {
+    let (constructor, _) = expression.var_constructor()?;
+    match &constructor.variant {
+        ValueConstructorVariant::LocalVariable { origin, .. } => {
+            function_parameter_index(function_name, origin)
+        }
+        ValueConstructorVariant::ModuleConstant { .. }
+        | ValueConstructorVariant::ModuleFn { .. }
+        | ValueConstructorVariant::Record { .. } => None,
+    }
+}
+
+fn is_unchanged_argument(function_name: &EcoString, argument: &TypedExpr, index: usize) -> bool {
+    expression_parameter_index(function_name, argument) == Some(index)
 }
 
 impl CurrentFunction {
@@ -244,6 +397,9 @@ pub(crate) struct Generator<'module, 'ast, 'doc> {
     // at the top level of the function to use in place of pushing new stack
     // frames.
     pub tail_recursion_used: bool,
+    /// Parameters whose current values must survive updates for the next iteration
+    /// and are unsafe to mutate directly.
+    pub loop_variable_arguments: HashSet<usize>,
     /// Statements to be compiled when lifting blocks into statement scope.
     /// For example, when compiling the following code:
     /// ```gleam
@@ -309,6 +465,7 @@ impl<'module, 'a, 'doc> Generator<'module, 'a, 'doc> {
             function_name,
             function_arguments,
             tail_recursion_used: false,
+            loop_variable_arguments: HashSet::new(),
             current_scope,
             current_function,
             function_position: Position::Tail,
@@ -342,6 +499,8 @@ impl<'module, 'a, 'doc> Generator<'module, 'a, 'doc> {
         body: &'a [TypedStatement],
         arguments: &'a [TypedArg],
     ) -> Document<'a, 'doc> {
+        self.loop_variable_arguments =
+            FunctionParameterReferences::collect(&self.function_name, body);
         let body = self.statements(arena, body);
         if self.tail_recursion_used {
             self.tail_call_loop(arena, body, arguments)
@@ -356,21 +515,25 @@ impl<'module, 'a, 'doc> Generator<'module, 'a, 'doc> {
         body: Document<'a, 'doc>,
         arguments: &'a [TypedArg],
     ) -> Document<'a, 'doc> {
-        let loop_assignments = arena.concat(arguments.iter().flat_map(|arg| {
-            arg.get_variable_name().map(|name| {
-                let var = maybe_escape_identifier(name);
-                docvec![
+        let loop_assignments =
+            arena.concat(arguments.iter().enumerate().filter_map(|(index, arg)| {
+                // only introduce a loop variable if we proved earlier that we need one.
+                if !self.loop_variable_arguments.contains(&index) {
+                    return None;
+                }
+                let name = arg.get_variable_name()?;
+                Some(docvec![
                     arena,
                     self.source_map_tracker(arena, arg.location.start),
                     LET_SPACE_DOCUMENT,
-                    var,
+                    maybe_escape_identifier(name),
                     SPACE_EQUAL_LOOP_DOLLAR_DOCUMENT,
                     name,
                     SEMICOLON_DOCUMENT,
                     LINE_DOCUMENT
-                ]
-            })
-        }));
+                ])
+            }));
+
         docvec![
             arena,
             WHILE_TRUE_OPEN_PAREN_DOCUMENT,
@@ -1827,6 +1990,15 @@ impl<'module, 'a, 'doc> Generator<'module, 'a, 'doc> {
         fun: &'a TypedExpr,
         arguments: &'a [TypedCallArg],
     ) -> Document<'a, 'doc> {
+        if let TypedExpr::Var { name, .. } = fun
+            && self.function_name == *name
+            && self.current_function.can_recurse()
+            && self.function_position.is_tail()
+            && self.current_scope.counter(name) == Some(0)
+        {
+            return self.tail_call(arena, arguments);
+        }
+
         let arguments = arguments
             .iter()
             .map(|element| {
@@ -1837,6 +2009,47 @@ impl<'module, 'a, 'doc> Generator<'module, 'a, 'doc> {
             .collect_vec();
 
         self.call_with_doc_arguments(arena, fun, arguments)
+    }
+
+    fn tail_call(
+        &mut self,
+        arena: &'doc DocumentArena<'a, 'doc>,
+        arguments: &'a [TypedCallArg],
+    ) -> Document<'a, 'doc> {
+        // Record that tail recursion is happening so that we know to
+        // render the loop at the top level of the function.
+        self.tail_recursion_used = true;
+
+        let mut assignments = Vec::with_capacity(arguments.len());
+
+        for (index, argument) in arguments.iter().enumerate() {
+            // If an argument is not changed, we don't need to re-assign it.
+            if is_unchanged_argument(&self.function_name, &argument.value, index) {
+                continue;
+            }
+
+            // Create an assignment for each variable created by the function arguments
+            let mut assignment = self.not_in_tail_position(Some(Ordering::Strict), |this| {
+                this.wrap_expression(arena, &argument.value)
+            });
+
+            // We either assign to the special loop variable or to the normal
+            // identifier directly, depending on if we needed to introduce the
+            // extra local binding earlier.
+            if let Some(&Some(name)) = self.function_arguments.get(index) {
+                let target = if self.loop_variable_arguments.contains(&index) {
+                    docvec![arena, LOOP_DOLLAR_DOCUMENT, name]
+                } else {
+                    maybe_escape_identifier(name).to_doc(arena)
+                };
+                assignment = docvec![arena, target, SPACE_EQUAL_SPACE_DOCUMENT, assignment];
+            }
+
+            // Render discarded values too as they may have side effects.
+            assignments.push(docvec![arena, assignment, SEMICOLON_DOCUMENT]);
+        }
+
+        arena.join(assignments, LINE_DOCUMENT)
     }
 
     fn call_with_doc_arguments(
@@ -1875,47 +2088,6 @@ impl<'module, 'a, 'doc> Generator<'module, 'a, 'doc> {
                     }
                 }
                 self.wrap_return(arena, construct_record(arena, None, name, arguments))
-            }
-
-            // Tail call optimisation. If we are calling the current function
-            // and we are in tail position we can avoid creating a new stack
-            // frame, enabling recursion with constant memory usage.
-            TypedExpr::Var { name, .. }
-                if self.function_name == *name
-                    && self.current_function.can_recurse()
-                    && self.function_position.is_tail()
-                    && self.current_scope.counter(name) == Some(0) =>
-            {
-                // Record that tail recursion is happening so that we know to
-                // render the loop at the top level of the function.
-                self.tail_recursion_used = true;
-                arena.concat(
-                    arguments
-                        .into_iter()
-                        .zip(&self.function_arguments)
-                        .enumerate()
-                        .map(|(i, (element, argument))| {
-                            let mut doc = EMPTY_DOCUMENT;
-
-                            if i != 0 {
-                                doc = doc.append(arena, LINE_DOCUMENT);
-                            }
-                            // Create an assignment for each variable created by the function arguments
-                            if let Some(name) = argument {
-                                doc = docvec![
-                                    arena,
-                                    doc,
-                                    LOOP_DOLLAR_DOCUMENT,
-                                    name.to_doc(arena),
-                                    SPACE_EQUAL_SPACE_DOCUMENT
-                                ];
-                            }
-                            // Render the value given to the function. Even if it is not
-                            // assigned we still render it because the expression may
-                            // have some side effects.
-                            docvec![arena, doc, element, SEMICOLON_DOCUMENT]
-                        }),
-                )
             }
 
             TypedExpr::Int { .. }
@@ -1995,7 +2167,7 @@ impl<'module, 'a, 'doc> Generator<'module, 'a, 'doc> {
         if let FunctionLiteralKind::Use { location } = kind {
             docs = docs.append(arena, self.source_map_tracker(arena, location.start));
         }
-        docs = docs.append(arena, fun_arguments(arena, arguments, false));
+        docs = docs.append(arena, fun_arguments(arena, arguments, None));
         docs = docs.append(arena, SPACE_EQUAL_ARROW_SPACE_OPEN_CURLY_DOCUMENT);
         docs = docs.append(arena, BREAKABLE_SPACE_DOCUMENT);
         docs = docs.append(arena, result);

--- a/compiler-core/src/javascript/tests/recursion.rs
+++ b/compiler-core/src/javascript/tests/recursion.rs
@@ -34,6 +34,91 @@ pub fn main(x) {
     );
 }
 
+#[test]
+fn tco_unchanged_argument_is_not_reassigned() {
+    assert_js!(
+        r#"
+pub fn main(x, unchanged) {
+  case x {
+    0 -> unchanged
+    _ -> main(x - 1, unchanged)
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn tco_captured_argument_uses_loop_variable() {
+    assert_js!(
+        r#"
+pub fn main(x, read) {
+  case x {
+    0 -> read()
+    _ -> main(x - 1, fn() { x })
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn tco_nested_call_preserves_outer_dependencies() {
+    assert_js!(
+        r#"
+pub fn main(x, y, remaining) {
+  case remaining {
+    0 -> x + y
+    _ -> main(x - 1, main(x, y, 0), remaining - 1)
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn tco_unchanged_parameter_read_by_later_argument() {
+    assert_js!(
+        r#"
+pub fn main(x, y, remaining) {
+  case remaining {
+    0 -> y
+    _ -> main(x, x, remaining - 1)
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn tco_evaluates_discarded_argument() {
+    assert_js!(
+        r#"
+@external(javascript, "utils", "observe")
+fn observe(x: Int) -> Int
+
+pub fn main(x, _) {
+  case x {
+    0 -> Nil
+    _ -> main(x - 1, observe(x))
+  }
+}
+"#
+    );
+}
+
+#[test]
+fn tco_shadowed_argument_is_reassigned() {
+    assert_js!(
+        r#"
+pub fn main(x) {
+  let x = x - 1
+  main(x)
+}
+"#
+    );
+}
+
 // https://github.com/gleam-lang/gleam/issues/1779
 #[test]
 fn not_tco_due_to_assignment() {

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__keyword_in_recursive_function.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__keyword_in_recursive_function.snap
@@ -9,9 +9,8 @@ pub fn main(with: Int) -> Nil {
 
 
 ----- COMPILED JAVASCRIPT
-export function main(loop$with) {
+export function main(with$) {
   while (true) {
-    let with$ = loop$with;
-    loop$with = with$ - 1;
+    with$ = with$ - 1;
   }
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__recursion_with_discards.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__recursion_with_discards.snap
@@ -10,11 +10,9 @@ pub fn main(f, _) {
 
 
 ----- COMPILED JAVASCRIPT
-export function main(loop$f, _) {
+export function main(f, _) {
   while (true) {
-    let f = loop$f;
     f();
-    loop$f = f;
     1;
   }
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__tail_call.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__tail_call.snap
@@ -15,16 +15,14 @@ pub fn count(xs, n) {
 ----- COMPILED JAVASCRIPT
 import { Empty as $Empty } from "../gleam.mjs";
 
-export function count(loop$xs, loop$n) {
+export function count(xs, n) {
   while (true) {
-    let xs = loop$xs;
-    let n = loop$n;
     if (xs instanceof $Empty) {
       return n;
     } else {
       let xs$1 = xs.tail;
-      loop$xs = xs$1;
-      loop$n = n + 1;
+      xs = xs$1;
+      n = n + 1;
     }
   }
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__tail_call_doesnt_clobber_tail_position_tracking.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__functions__tail_call_doesnt_clobber_tail_position_tracking.snap
@@ -13,12 +13,11 @@ pub fn loop(indentation) {
 
 
 ----- COMPILED JAVASCRIPT
-export function loop(loop$indentation) {
+export function loop(indentation) {
   while (true) {
-    let indentation = loop$indentation;
     let $ = indentation > 0;
     if ($) {
-      loop$indentation = indentation - 1;
+      indentation = indentation - 1;
     } else {
       return undefined;
     }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__recursion__tco.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__recursion__tco.snap
@@ -13,13 +13,12 @@ pub fn main(x) {
 
 
 ----- COMPILED JAVASCRIPT
-export function main(loop$x) {
+export function main(x) {
   while (true) {
-    let x = loop$x;
     if (x === 0) {
       return undefined;
     } else {
-      loop$x = x - 1;
+      x = x - 1;
     }
   }
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__recursion__tco_captured_argument_uses_loop_variable.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__recursion__tco_captured_argument_uses_loop_variable.snap
@@ -1,0 +1,26 @@
+---
+source: compiler-core/src/javascript/tests/recursion.rs
+expression: "\npub fn main(x, read) {\n  case x {\n    0 -> read()\n    _ -> main(x - 1, fn() { x })\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main(x, read) {
+  case x {
+    0 -> read()
+    _ -> main(x - 1, fn() { x })
+  }
+}
+
+
+----- COMPILED JAVASCRIPT
+export function main(loop$x, read) {
+  while (true) {
+    let x = loop$x;
+    if (x === 0) {
+      return read();
+    } else {
+      loop$x = x - 1;
+      read = () => { return x; };
+    }
+  }
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__recursion__tco_case_block.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__recursion__tco_case_block.snap
@@ -16,14 +16,13 @@ pub fn main(x) {
 
 
 ----- COMPILED JAVASCRIPT
-export function main(loop$x) {
+export function main(x) {
   while (true) {
-    let x = loop$x;
     if (x === 0) {
       return undefined;
     } else {
       let y = x;
-      loop$x = y - 1;
+      x = y - 1;
     }
   }
 }

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__recursion__tco_evaluates_discarded_argument.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__recursion__tco_evaluates_discarded_argument.snap
@@ -1,0 +1,31 @@
+---
+source: compiler-core/src/javascript/tests/recursion.rs
+expression: "\n@external(javascript, \"utils\", \"observe\")\nfn observe(x: Int) -> Int\n\npub fn main(x, _) {\n  case x {\n    0 -> Nil\n    _ -> main(x - 1, observe(x))\n  }\n}\n"
+---
+----- SOURCE CODE
+
+@external(javascript, "utils", "observe")
+fn observe(x: Int) -> Int
+
+pub fn main(x, _) {
+  case x {
+    0 -> Nil
+    _ -> main(x - 1, observe(x))
+  }
+}
+
+
+----- COMPILED JAVASCRIPT
+import { observe } from "utils";
+
+export function main(loop$x, _) {
+  while (true) {
+    let x = loop$x;
+    if (x === 0) {
+      return undefined;
+    } else {
+      loop$x = x - 1;
+      observe(x);
+    }
+  }
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__recursion__tco_nested_call_preserves_outer_dependencies.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__recursion__tco_nested_call_preserves_outer_dependencies.snap
@@ -1,0 +1,27 @@
+---
+source: compiler-core/src/javascript/tests/recursion.rs
+expression: "\npub fn main(x, y, remaining) {\n  case remaining {\n    0 -> x + y\n    _ -> main(x - 1, main(x, y, 0), remaining - 1)\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main(x, y, remaining) {
+  case remaining {
+    0 -> x + y
+    _ -> main(x - 1, main(x, y, 0), remaining - 1)
+  }
+}
+
+
+----- COMPILED JAVASCRIPT
+export function main(loop$x, y, remaining) {
+  while (true) {
+    let x = loop$x;
+    if (remaining === 0) {
+      return x + y;
+    } else {
+      loop$x = x - 1;
+      y = main(x, y, 0);
+      remaining = remaining - 1;
+    }
+  }
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__recursion__tco_shadowed_argument_is_reassigned.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__recursion__tco_shadowed_argument_is_reassigned.snap
@@ -1,0 +1,19 @@
+---
+source: compiler-core/src/javascript/tests/recursion.rs
+expression: "\npub fn main(x) {\n  let x = x - 1\n  main(x)\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main(x) {
+  let x = x - 1
+  main(x)
+}
+
+
+----- COMPILED JAVASCRIPT
+export function main(x) {
+  while (true) {
+    let x$1 = x - 1;
+    x = x$1;
+  }
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__recursion__tco_unchanged_argument_is_not_reassigned.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__recursion__tco_unchanged_argument_is_not_reassigned.snap
@@ -1,0 +1,24 @@
+---
+source: compiler-core/src/javascript/tests/recursion.rs
+expression: "\npub fn main(x, unchanged) {\n  case x {\n    0 -> unchanged\n    _ -> main(x - 1, unchanged)\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main(x, unchanged) {
+  case x {
+    0 -> unchanged
+    _ -> main(x - 1, unchanged)
+  }
+}
+
+
+----- COMPILED JAVASCRIPT
+export function main(x, unchanged) {
+  while (true) {
+    if (x === 0) {
+      return unchanged;
+    } else {
+      x = x - 1;
+    }
+  }
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__recursion__tco_unchanged_parameter_read_by_later_argument.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__recursion__tco_unchanged_parameter_read_by_later_argument.snap
@@ -1,0 +1,25 @@
+---
+source: compiler-core/src/javascript/tests/recursion.rs
+expression: "\npub fn main(x, y, remaining) {\n  case remaining {\n    0 -> y\n    _ -> main(x, x, remaining - 1)\n  }\n}\n"
+---
+----- SOURCE CODE
+
+pub fn main(x, y, remaining) {
+  case remaining {
+    0 -> y
+    _ -> main(x, x, remaining - 1)
+  }
+}
+
+
+----- COMPILED JAVASCRIPT
+export function main(x, y, remaining) {
+  while (true) {
+    if (remaining === 0) {
+      return y;
+    } else {
+      y = x;
+      remaining = remaining - 1;
+    }
+  }
+}

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__sourcemaps__sourcemap_with_tail_recursive_functions.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__sourcemaps__sourcemap_with_tail_recursive_functions.snap
@@ -15,20 +15,18 @@ expression: "\npub fn wibble(lon, acc) {\n  case lon {\n    [] -> 0\n    [n, ..r
 0 |//# sourceMappingURL=mod.mjs.map
 1 |import { Empty as $Empty } from "../gleam.mjs";
 2 |
-3 |export function wibble(loop$lon, loop$acc) {
+3 |export function wibble(lon, acc) {
 4 |  while (true) {
-5 |    let lon = loop$lon;
-6 |    let acc = loop$acc;
-7 |    if (lon instanceof $Empty) {
-8 |      return 0;
-9 |    } else {
-10 |      let n = lon.head;
-11 |      let rest = lon.tail;
-12 |      loop$lon = rest;
-13 |      loop$acc = acc + n;
-14 |    }
-15 |  }
-16 |}
+5 |    if (lon instanceof $Empty) {
+6 |      return 0;
+7 |    } else {
+8 |      let n = lon.head;
+9 |      let rest = lon.tail;
+10 |      lon = rest;
+11 |      acc = acc + n;
+12 |    }
+13 |  }
+14 |}
 
 ----- SOURCE MAP
 File: my/mod.mjs
@@ -43,21 +41,11 @@ import { Empty as $Empty } from "../gleam.mjs";
 
 
 ----- 
-pub fn wibble(
-⏷
-export function wibble(loop$lon, loop$acc) {
-  while (true) {
-    
------ 
-lon, 
-⏷
-let lon = loop$lon;
-    
------ 
-acc) {
+pub fn wibble(lon, acc) {
   
 ⏷
-let acc = loop$acc;
+export function wibble(lon, acc) {
+  while (true) {
     
 ----- 
 case 
@@ -85,12 +73,12 @@ let n = lon.head;
 ----- 
 wibble(
 ⏷
-loop$lon = 
+lon = 
 ----- 
 rest, 
 ⏷
 rest;
-      loop$acc = 
+      acc = 
 ----- 
 acc + 
 ⏷

--- a/test/language/test/language/tail_call_test.gleam
+++ b/test/language/test/language/tail_call_test.gleam
@@ -19,6 +19,89 @@ fn function_shadowed_by_own_argument(function_shadowed_by_own_argument) {
   function_shadowed_by_own_argument()
 }
 
+fn recursive_argument_closure(x, read) {
+  case x {
+    0 -> read()
+    _ -> recursive_argument_closure(x - 1, fn() { x })
+  }
+}
+
+fn rotate_arguments(x, y, remaining) {
+  case remaining {
+    0 -> #(x, y)
+    _ -> rotate_arguments(y, x, remaining - 1)
+  }
+}
+
+fn nested_recursive_arguments(x, y, remaining) {
+  case remaining {
+    0 -> x + y
+    _ ->
+      nested_recursive_arguments(
+        x - 1,
+        nested_recursive_arguments(x, y, 0),
+        remaining - 1,
+      )
+  }
+}
+
+fn discarded_recursive_argument(x, _) {
+  case x {
+    0 -> Nil
+    _ ->
+      discarded_recursive_argument(x - 1, {
+        assert x > 0
+        Nil
+      })
+  }
+}
+
+fn recursive_guard_closure(x, read) {
+  case x {
+    0 -> read()
+    _ ->
+      recursive_guard_closure(x - 1, fn() {
+        case Nil {
+          _ if x == 1 -> True
+          _ -> False
+        }
+      })
+  }
+}
+
+fn recursive_guard_argument(x, result) {
+  case x {
+    0 -> result
+    _ ->
+      recursive_guard_argument(x - 1, case Nil {
+        _ if x == 1 -> True
+        _ -> False
+      })
+  }
+}
+
+fn recursive_size_closure(x, read) {
+  case x {
+    0 -> read()
+    _ ->
+      recursive_size_closure(x - 1, fn() {
+        let assert <<value:size(x), _:bits>> = <<128>>
+        value
+      })
+  }
+}
+
+fn recursive_size_argument(x, result) {
+  case x {
+    0 -> result
+    _ ->
+      recursive_size_argument(x - 1, {
+        let assert <<value:size(x), _:bits>> = <<128>>
+        value
+      })
+  }
+}
+
 pub fn ten_million_recursions_doesnt_overflow_the_stack_test() {
   assert Nil == count_down(from: 10_000_000)
 }
@@ -27,6 +110,40 @@ pub fn ten_million_recursions_doesnt_overflow_the_stack_test() {
 // https://github.com/gleam-lang/gleam/issues/1380
 pub fn arguments_correctly_reassigned_test() {
   assert [1, 2, 3] == tail_recursive_accumulate_down(3, [])
+}
+
+pub fn recursive_argument_closure_captures_fresh_binding_test() {
+  assert 1 == recursive_argument_closure(2, fn() { 0 })
+}
+
+pub fn recursive_arguments_are_updated_simultaneously_test() {
+  assert #(2, 1) == rotate_arguments(1, 2, 1)
+  assert #(1, 2) == rotate_arguments(1, 2, 2)
+}
+
+pub fn nested_recursive_arguments_read_previous_values_test() {
+  assert 6 == nested_recursive_arguments(2, 3, 1)
+  assert 10 == nested_recursive_arguments(3, 4, 2)
+}
+
+pub fn discarded_recursive_argument_reads_previous_value_test() {
+  assert Nil == discarded_recursive_argument(2, Nil)
+}
+
+pub fn recursive_guard_closure_captures_fresh_binding_test() {
+  assert True == recursive_guard_closure(2, fn() { False })
+}
+
+pub fn recursive_guard_argument_reads_previous_value_test() {
+  assert True == recursive_guard_argument(2, False)
+}
+
+pub fn recursive_size_closure_captures_fresh_binding_test() {
+  assert 1 == recursive_size_closure(2, fn() { 0 })
+}
+
+pub fn recursive_size_argument_reads_previous_value_test() {
+  assert 1 == recursive_size_argument(2, 0)
 }
 
 // https://github.com/gleam-lang/gleam/issues/2400


### PR DESCRIPTION
Unfortunately, this turned out to be a bit worse than anticipated as it's a bit offset in real Lustre programs by the small-list optimisation, and I didn't realise I chose a non-representative example in the original issue.

Compiler | Unminified | Minified | Minified+Gzip
-- | -- | -- | --
v1.18.0 | 163,424 B | 54,423 B | 17,574 B
smaller-tco | 147,093 B (−9.99%) | 52,368 B (−3.78%) | 17,204 B (−2.11%)

Here I compare the routing example from Lustre, were the previous comparison was the diff benchmark. The absolute improvements were roughly accurate.

Closes #6273

- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked above
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes
