### PR TITLE
Fix TypeScript references to types from aliased modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -333,6 +333,10 @@
   inside the project.
   ([John Downey](https://github.com/jtdowney))
 
+- Fixed a bug in generating TypeScript annotations for function signatures
+  that use types from aliased modules.
+  ([Ian Chamberlain](https://github.com/ian-h-chamberlain))
+
 ## v1.18.1 - 2026-08-01
 
 - Fixed a bug where the Erlang code generator would generate wrong code when

--- a/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__typescript__type_from_renamed_module.snap
+++ b/compiler-core/src/javascript/tests/snapshots/gleam_core__javascript__tests__typescript__type_from_renamed_module.snap
@@ -1,0 +1,15 @@
+---
+source: compiler-core/src/javascript/tests/typescript.rs
+assertion_line: 48
+expression: "\nimport x as y\npub fn foo() -> y.Obj { }\n"
+---
+----- SOURCE CODE
+
+import x as y
+pub fn foo() -> y.Obj { }
+
+
+----- TYPESCRIPT DEFINITIONS
+import type * as $y from "../x.d.mts";
+
+export function foo(): $y.Obj$;

--- a/compiler-core/src/javascript/tests/typescript.rs
+++ b/compiler-core/src/javascript/tests/typescript.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2022 The Gleam contributors
 
 use crate::assert_ts_def;
+use crate::javascript::tests::CURRENT_PACKAGE;
 
 // https://github.com/gleam-lang/gleam/issues/5715
 #[test]
@@ -39,5 +40,16 @@ pub type Twin {
     Tom
 }
 "
+    );
+}
+
+#[test]
+fn type_from_renamed_module() {
+    assert_ts_def!(
+        (CURRENT_PACKAGE, "x", r#"pub type Obj"#),
+        r#"
+import x as y
+pub fn foo() -> y.Obj { }
+"#,
     );
 }

--- a/compiler-core/src/javascript/typescript.rs
+++ b/compiler-core/src/javascript/typescript.rs
@@ -238,6 +238,17 @@ impl<'a, 'doc> TypeScriptGenerator<'a> {
     fn collect_imports(&mut self) -> Imports<'a, 'doc> {
         let mut imports = Imports::new();
 
+        // Collect imports first, so we can look up module aliases in subsequent
+        // definitions and resolve the real module when emitting those type decls.
+        for import in &self.module.definitions.imports {
+            match &import.as_name {
+                Some((AssignName::Variable(name), _)) => {
+                    let _ = self.aliased_module_names.insert(&import.module, name);
+                }
+                Some((AssignName::Discard(_), _)) | None => (),
+            }
+        }
+
         for function in &self.module.definitions.functions {
             for argument in &function.arguments {
                 self.collect_imports_for_type(&argument.type_, &mut imports);
@@ -263,15 +274,6 @@ impl<'a, 'doc> TypeScriptGenerator<'a> {
 
         for constant in &self.module.definitions.constants {
             self.collect_imports_for_type(&constant.type_, &mut imports);
-        }
-
-        for import in &self.module.definitions.imports {
-            match &import.as_name {
-                Some((AssignName::Variable(name), _)) => {
-                    let _ = self.aliased_module_names.insert(&import.module, name);
-                }
-                Some((AssignName::Discard(_), _)) | None => (),
-            }
         }
 
         imports


### PR DESCRIPTION
Closes #6286

- [x] The changes in this PR have been discussed beforehand in an issue
- [x] The issue for this PR has been linked above
- [x] Tests have been added for new behaviour
- [x] The changelog has been updated for any user-facing changes

By looking up modules first when emitting typescript declarations, aliased modules will be resolved properly.

Before:

```gleam
import x as y
pub fn foo() -> y.Obj { }
```

Generated declarations:
```ts
import type * as $x from "../x.d.mts";

export function foo(): $y.Obj$;
```

After:
```ts
import type * as $y from "../x.d.mts";

export function foo(): $y.Obj$;
```