### PR TITLE
Bump chacha20 version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,9 +533,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -3012,7 +3012,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20 0.10.1",
+ "chacha20 0.10.2",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]


### PR DESCRIPTION
While running `make install`, I got the warning:

```
warning: package `chacha20 v0.10.1` in Cargo.lock is yanked in registry `crates-io`
  |
  = help: consider running without --locked
```

And I saw that the v0.10.1 release was yanked from crates.io